### PR TITLE
Add comprehensive unit tests for chat provider components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 out
+out-tests
 .vscode-test
 *.vsix
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p .",
-    "watch": "tsc -watch -p ."
+    "watch": "tsc -watch -p .",
+    "test:build": "tsc -p tsconfig.tests.json",
+    "test": "npm run test:build && node --test \"out-tests/test/**/*.js\""
   },
   "devDependencies": {
     "@types/node": "^20.12.8",

--- a/test/anthropicLikeClient.test.ts
+++ b/test/anthropicLikeClient.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert';
+import test, { mock } from 'node:test';
+import Module from 'node:module';
+
+const configurationValues = {
+  endpoints: [
+    { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com/anthropic', models: ['deepseek-chat'] },
+  ],
+};
+
+const vscodeMock = {
+  workspace: {
+    getConfiguration: (section?: string) => {
+      if (section === 'unifyChatProviders') {
+        return {
+          get: (key: string, defaultValue?: unknown) => (configurationValues as any)[key] ?? defaultValue,
+        } as any;
+      }
+      return { update: async () => undefined } as any;
+    },
+    onDidChangeConfiguration: () => ({ dispose() {} }),
+  },
+  ConfigurationTarget: { Workspace: 'workspace' },
+  window: {
+    showInformationMessage: () => undefined,
+    showErrorMessage: () => undefined,
+    showInputBox: async () => undefined,
+    showQuickPick: async () => undefined,
+  },
+  commands: { registerCommand: () => ({ dispose() {} }) },
+  lm: { registerChatParticipant: () => ({ dispose() {} }) },
+};
+
+const originalLoad = (Module as any)._load;
+(Module as any)._load = (request: string, parent: any, isMain: boolean) => {
+  if (request === 'vscode') {
+    return vscodeMock;
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+test('AnthropicLikeClient handles JSON responses', async () => {
+  const { AnthropicLikeClient } = await import('../src/extension');
+  const markdown: string[] = [];
+  const stream = { markdown: (value: string) => markdown.push(value) } as any;
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as any;
+
+  global.fetch = mock.fn(async () => ({
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => ({ content: [{ text: 'Hello from DeepSeek' }] }),
+    body: null,
+  })) as any;
+
+  const client = new AnthropicLikeClient({ name: 'DeepSeek', baseUrl: 'https://api.deepseek.com/anthropic', models: ['deepseek-chat'] });
+  await client.sendChat([], 'Hi there', 'deepseek-chat', stream, token);
+
+  assert.deepStrictEqual(markdown, ['Hello from DeepSeek']);
+  assert.strictEqual((fetch as any).mock.calls.length, 1);
+});
+
+test('AnthropicLikeClient streams SSE responses', async () => {
+  const { AnthropicLikeClient } = await import('../src/extension');
+  const markdown: string[] = [];
+  const stream = { markdown: (value: string) => markdown.push(value) } as any;
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as any;
+
+  const encoder = new TextEncoder();
+  const chunks = [
+    'data: {"delta": {"text": "Hello"}}\n\n',
+    'data: {"delta": {"text": " world"}}\n\n',
+    'data: [DONE]\n\n',
+  ];
+  const reader = {
+    index: 0,
+    async read() {
+      if (this.index >= chunks.length) {
+        return { done: true, value: undefined };
+      }
+      const value = encoder.encode(chunks[this.index]);
+      this.index += 1;
+      return { done: false, value };
+    },
+  };
+
+  global.fetch = mock.fn(async () => ({
+    ok: true,
+    headers: new Headers({ 'content-type': 'text/event-stream' }),
+    body: { getReader: () => reader },
+  })) as any;
+
+  const client = new AnthropicLikeClient({ name: 'DeepSeek', baseUrl: 'https://api.deepseek.com/anthropic', models: ['deepseek-chat'] });
+  await client.sendChat([], 'Stream request', 'deepseek-chat', stream, token);
+
+  assert.deepStrictEqual(markdown, ['Hello', ' world']);
+});
+
+test('AnthropicLikeClient surfaces HTTP failures', async () => {
+  const { AnthropicLikeClient } = await import('../src/extension');
+  const stream = { markdown: () => undefined } as any;
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as any;
+
+  global.fetch = async () => ({
+    ok: false,
+    status: 500,
+    text: async () => 'Service unavailable',
+    headers: new Headers(),
+    body: null,
+  }) as any;
+
+  const client = new AnthropicLikeClient({ name: 'DeepSeek', baseUrl: 'https://api.deepseek.com/anthropic', models: ['deepseek-chat'] });
+  await assert.rejects(() => client.sendChat([], 'Hi', 'deepseek-chat', stream, token), /Request failed with status 500/);
+});

--- a/test/chatProviderService.test.ts
+++ b/test/chatProviderService.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert';
+import test, { mock } from 'node:test';
+import Module from 'node:module';
+
+const configurationValues = {
+  endpoints: [
+    {
+      name: 'DeepSeek',
+      baseUrl: 'https://api.deepseek.com/anthropic',
+      models: ['deepseek-chat', 'deepseek-chat-alt'],
+      defaultModel: 'deepseek-chat',
+    },
+    {
+      name: 'Second',
+      baseUrl: 'https://second.example/v1/messages',
+      models: ['s1'],
+    },
+  ],
+  activeProvider: 'Second',
+  activeModel: '',
+};
+
+const registeredParticipants: any[] = [];
+
+const vscodeMock = {
+  workspace: {
+    getConfiguration: (section?: string) => {
+      if (section === 'unifyChatProviders') {
+        return {
+          get: (key: string, defaultValue?: unknown) => (configurationValues as any)[key] ?? defaultValue,
+        } as any;
+      }
+      return {
+        update: async (key: string, value: unknown) => {
+          (configurationValues as any)[key] = value;
+        },
+      } as any;
+    },
+    onDidChangeConfiguration: () => ({ dispose() {} }),
+  },
+  ConfigurationTarget: { Workspace: 'workspace' },
+  window: {
+    showInformationMessage: () => undefined,
+    showErrorMessage: () => undefined,
+    showInputBox: async () => undefined,
+    showQuickPick: async () => undefined,
+  },
+  commands: { registerCommand: () => ({ dispose() {} }) },
+  lm: {
+    registerChatParticipant: (identifier: string, participant: any) => {
+      registeredParticipants.push({ identifier, participant });
+      return { dispose() {} };
+    },
+  },
+};
+
+const originalLoad = (Module as any)._load;
+(Module as any)._load = (request: string, parent: any, isMain: boolean) => {
+  if (request === 'vscode') {
+    return vscodeMock;
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+test('ChatProviderService resolves active endpoint and model', async () => {
+  const { ChatProviderService } = await import('../src/extension');
+  const service = new ChatProviderService({ subscriptions: [] } as any);
+
+  const result = (service as any).getActiveEndpoint();
+  assert.ok(result);
+  assert.strictEqual(result?.endpoint.name, 'Second');
+  assert.strictEqual(result?.model, 's1');
+});
+
+test('ChatProviderService registers participant from configuration', async () => {
+  registeredParticipants.length = 0;
+  const { ChatProviderService } = await import('../src/extension');
+  const service = new ChatProviderService({ subscriptions: [] } as any);
+  const stubClient = { sendChat: mock.fn(async () => undefined) };
+  (service as any).createClient = () => stubClient;
+
+  (service as any).registerFromConfiguration();
+
+  assert.strictEqual(registeredParticipants.length > 0, true);
+  const registration = registeredParticipants[registeredParticipants.length - 1];
+  const participant = registration.participant;
+  const markdown: string[] = [];
+  const stream = { markdown: (value: string) => markdown.push(value) } as any;
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as any;
+
+  await participant.handleChatRequest({ messages: [], prompt: '' }, {}, stream, token);
+  assert.deepStrictEqual(markdown, ['No prompt provided.']);
+  assert.strictEqual(stubClient.sendChat.mock.calls.length, 0);
+
+  await participant.handleChatRequest(
+    {
+      messages: [
+        { role: 'user', content: [{ text: 'Hello' }] },
+        { role: 'assistant', content: [{ text: 'Hi there' }] },
+      ],
+      prompt: 'New prompt',
+    },
+    {},
+    stream,
+    token,
+  );
+
+  assert.strictEqual(stubClient.sendChat.mock.calls.length, 1);
+  const [history, prompt, model] = stubClient.sendChat.mock.calls[0].arguments;
+  assert.deepStrictEqual(history, [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi there' },
+  ]);
+  assert.strictEqual(prompt, 'New prompt');
+  assert.strictEqual(model, 's1');
+});
+
+test('ChatProviderService skips registration when configuration is invalid', async () => {
+  registeredParticipants.length = 0;
+  configurationValues.endpoints = [];
+  const { ChatProviderService } = await import('../src/extension');
+  const service = new ChatProviderService({ subscriptions: [] } as any);
+  (service as any).registerFromConfiguration();
+
+  assert.strictEqual((service as any).registration, undefined);
+
+  configurationValues.endpoints = [
+    {
+      name: 'DeepSeek',
+      baseUrl: 'https://api.deepseek.com/anthropic',
+      models: ['deepseek-chat', 'deepseek-chat-alt'],
+      defaultModel: 'deepseek-chat',
+    },
+    {
+      name: 'Second',
+      baseUrl: 'https://second.example/v1/messages',
+      models: ['s1'],
+    },
+  ];
+});

--- a/test/node-shims.d.ts
+++ b/test/node-shims.d.ts
@@ -1,0 +1,62 @@
+declare module 'node:assert' {
+  import assert = require('assert');
+  export = assert;
+}
+
+declare module 'node:test' {
+  export interface MockCall {
+    arguments: any[];
+  }
+
+  export interface MockFunction {
+    (...args: any[]): any;
+    mock: { calls: MockCall[] };
+  }
+
+  export const mock: {
+    fn: (implementation?: (...args: any[]) => any) => MockFunction;
+    module: (specifier: string, factory: () => any) => void;
+  };
+
+  type TestFn = (name: string, fn: (...args: any[]) => any) => any;
+  const test: TestFn;
+  export default test;
+}
+
+declare const global: any;
+
+declare module 'vscode' {
+  export interface Disposable {
+    dispose(): void;
+  }
+
+  export interface ChatResponseStream {
+    markdown(value: string): void;
+  }
+
+  export interface CancellationToken {
+    isCancellationRequested: boolean;
+    onCancellationRequested(callback: () => void): Disposable;
+  }
+
+  export interface ExtensionContext {
+    subscriptions: Array<Disposable>;
+  }
+
+  export interface ConfigurationChangeEvent {
+    affectsConfiguration(section: string): boolean;
+  }
+
+  export const workspace: any;
+  export const window: any;
+  export const commands: any;
+  export const lm: any;
+  export enum ConfigurationTarget {
+    Workspace,
+  }
+}
+
+declare module 'node:module' {
+  const Module: any;
+  export = Module;
+}

--- a/test/providerStore.test.ts
+++ b/test/providerStore.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import Module from 'node:module';
+
+const updates: Array<{ key: string; value: unknown; target: unknown }> = [];
+const configurationValues = {
+  endpoints: [
+    { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com/anthropic', models: ['deepseek-chat'] },
+  ],
+  activeProvider: 'DeepSeek',
+  activeModel: 'deepseek-chat',
+};
+
+const vscodeMock = {
+  workspace: {
+    getConfiguration: (section?: string) => {
+      if (section === 'unifyChatProviders') {
+        return {
+          get: (key: string, defaultValue?: unknown) => (configurationValues as any)[key] ?? defaultValue,
+        } as any;
+      }
+
+      return {
+        update: async (key: string, value: unknown, target: unknown) => {
+          updates.push({ key, value, target });
+          (configurationValues as any)[key] = value;
+        },
+      } as any;
+    },
+  },
+  ConfigurationTarget: { Workspace: 'workspace' },
+  window: {
+    showInformationMessage: () => undefined,
+    showErrorMessage: () => undefined,
+    showInputBox: async () => undefined,
+    showQuickPick: async () => undefined,
+  },
+  commands: { registerCommand: () => ({ dispose() {} }) },
+  lm: { registerChatParticipant: () => ({ dispose() {} }) },
+};
+
+const originalLoad = (Module as any)._load;
+(Module as any)._load = (request: string, parent: any, isMain: boolean) => {
+  if (request === 'vscode') {
+    return vscodeMock;
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+test('ProviderStore exposes workspace configuration and writes updates', async () => {
+  const { ProviderStore } = await import('../src/extension');
+  const store = new ProviderStore();
+
+  const config = store.configuration;
+  assert.strictEqual(config.activeProvider, 'DeepSeek');
+  assert.strictEqual(config.activeModel, 'deepseek-chat');
+  assert.strictEqual(config.endpoints[0].name, 'DeepSeek');
+
+  await store.setEndpoints([{ name: 'Second', baseUrl: 'https://example', models: ['m1'] }]);
+  await store.setActiveProvider('Second');
+  await store.setActiveModel('m1');
+
+  assert.deepStrictEqual(updates[0], {
+    key: 'unifyChatProviders.endpoints',
+    value: [{ name: 'Second', baseUrl: 'https://example', models: ['m1'] }],
+    target: 'workspace',
+  });
+  assert.deepStrictEqual(updates[1], {
+    key: 'unifyChatProviders.activeProvider',
+    value: 'Second',
+    target: 'workspace',
+  });
+  assert.deepStrictEqual(updates[2], {
+    key: 'unifyChatProviders.activeModel',
+    value: 'm1',
+    target: 'workspace',
+  });
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "out-tests",
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated test TypeScript config and npm test script using the Node test runner
- export extension internals and provide local shims to enable unit testing without VS Code dependencies
- add unit tests for the provider store, chat client streaming, and chat participant registration flows

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dcf1d8720832499fc6f2925fe327b)