### PR TITLE
fix(openai-chat-completion): guard missing stream delta to prevent crash

### DIFF
--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -1012,11 +1012,14 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
         continue;
       }
 
-      const { content } = choice.delta;
+      const delta = choice.delta;
+      const content = delta?.content;
 
       recordFirstToken();
 
-      yield* this.extractThinkingParts(choice.delta, 'content-only');
+      if (delta) {
+        yield* this.extractThinkingParts(delta, 'content-only');
+      }
 
       if (content) {
         for (const segment of thinkingTagParser.push(content)) {


### PR DESCRIPTION
<font class="fy-translate inserted-translation-tags qx_no_translate" lang="en">
                                  
                                  <font class="inserted-translation-control">
                                      <font class="inserted-translation-content"><font class="fy-translate inserted-translation-tags qx_no_translate" lang="en">
                                  
                                  <font class="inserted-translation-control">
                                      <font class="inserted-translation-content"><font class="fy-translate inserted-translation-tags qx_no_translate" lang="en">
 
 <font class="inserted-translation-control">
<font class="inserted-translation-content">一些流式块可能会省略choice.delta（例如finish_reason-only 块）。 

之前parseMessageStream 直接解构choice.delta.content，当delta 未定义时导致TypeError。 

此更改可以安全地读取delta/content，并且仅在delta 存在时提取思考部分。</font> 
</font> 
</font></font>
                                  </font>
                              </font></font>
                                  </font>
                              </font>