### PR TITLE
Clarify model picker labels with provider suffix.

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -88,6 +88,7 @@ export class UnifyChatService implements vscode.LanguageModelChatProvider {
     model: ModelConfig,
   ): vscode.LanguageModelChatInformation {
     const modelId = this.createModelId(provider.name, model.id);
+    const displayName = `${model.name ?? model.id} [${provider.name}]`;
     const balanceSnapshot = this.balanceManager?.getProviderState(
       provider.name,
     )?.snapshot;
@@ -104,7 +105,7 @@ export class UnifyChatService implements vscode.LanguageModelChatProvider {
 
     return {
       id: modelId,
-      name: model.name ?? model.id,
+      name: displayName,
       family: model.family ?? getBaseModelId(model.id),
       version: '',
       maxInputTokens: model.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS,


### PR DESCRIPTION
This PR improves model disambiguation in the picker by displaying labels as <Model> [<Provider>].

For example:
GLM-4.7 [Z.AI]
GLM-4.7 [Nvidia]
GLM-4.7 [SiliconFlow (International)]
Scope is minimal: display label only. No changes to model IDs, auth, provider routing, or request execution, nothing more (at least was not intended).

Sugestions:
- Add a quick enable/disable toggle for providers without deleting them.
- Add provider-based ordering/grouping in the model list.

Wishing success to your project, plz keeps updating. This PR was prepared and validated using the extension workflow itself (including its own model picker). Congrats Menon/Copilot.
