### PR TITLE
fix: reuse API key secret refs across synced devices

### DIFF
--- a/src/auth/providers/api-key/index.ts
+++ b/src/auth/providers/api-key/index.ts
@@ -300,7 +300,11 @@ export class ApiKeyAuthProvider implements AuthProvider {
       `${this.context.providerId}:api-key`,
       'Storing new API key in secret storage',
     );
-    const secretRef = createSecretRef();
+    const existingRef =
+      this.config?.apiKey && isSecretRef(this.config.apiKey)
+        ? this.config.apiKey
+        : undefined;
+    const secretRef = existingRef ?? createSecretRef();
     await this.context.secretStore.setApiKey(secretRef, trimmed);
 
     const next: ApiKeyAuthConfig = {


### PR DESCRIPTION
## Summary

Fix an API key settings sync loop that caused users to re-enter the same key every time they switched between machines.

## Failure case

When a provider was configured with an API key stored in SecretStorage, the synced settings only contained the `$UCPSECRET:...$` reference while the actual secret stayed local to each machine.

If a second machine synced the settings but did not have the referenced secret locally, re-entering the key caused the extension to generate a brand new secret reference and write that new reference back into synced settings.

That invalidated the first machine's config on the next sync, because it still had the old local secret but settings now pointed at a different reference. Switching between devices repeated this cycle indefinitely.

## Fix

Reuse the existing secret reference when the current API key config already points to one. That allows a machine with a missing local secret to repopulate SecretStorage for the existing synced reference instead of rotating the reference and breaking other devices.

## Validation

- `npm run compile`
