### PR TITLE
Refine tool_calls condition in chat-completion-client

### DIFF
--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -1216,7 +1216,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
             role: 'assistant',
             ...(content ? { content } : {}),
             ...(refusal ? { refusal } : {}),
-            ...(tool_calls ? { tool_calls } : {}),
+            ...(tool_calls && tool_calls.length > 0 ? { tool_calls } : {}),
             ...(reasoning ? { reasoning } : {}),
             ...(reasoning_content ? { reasoning_content } : {}),
             ...(reasoning_details ? { reasoning_details } : {}),


### PR DESCRIPTION
This condition currently allows tool_calls to be an empty array, but models like Qwen will reject requests with the "Empty tool_calls is not supported in message" error message. When this array is empty, omitting it altogether allows these models to work properly.