### PR TITLE
Add a new model configuration option that omits the 'tools' block in

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -145,6 +145,8 @@
   "Allow parallel tool calls": "Allow parallel tool calls",
   "Disable": "Disable",
   "Disallow parallel tool calls": "Disallow parallel tool calls",
+  "Omit Tools Definition": "Omit Tools Definition",
+  "Omit tools block in API calls": "Omit tools block in API calls",
   "enable": "enable",
   "disable": "disable",
   "Image Input Support": "Image Input Support",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -145,6 +145,8 @@
   "Allow parallel tool calls": "允许并行工具调用",
   "Disable": "禁用",
   "Disallow parallel tool calls": "不允许并行工具调用",
+  "Omit Tools Definition": "省略工具定义",
+  "Omit tools block in API calls": "在 API 调用中省略 tools 块",
   "enable": "启用",
   "disable": "禁用",
   "Image Input Support": "图像输入支持",

--- a/package.json
+++ b/package.json
@@ -711,6 +711,10 @@
                           "type": "boolean",
                           "description": "%configuration.endpoints.models.parallelToolCalling.description%"
                         },
+                        "omitToolsDefinition": {
+                          "type": "boolean",
+                          "description": "%configuration.endpoints.models.omitToolsDefinition.description%"
+                        },
                         "stream": {
                           "type": "boolean",
                           "description": "%configuration.endpoints.models.stream.description%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -110,6 +110,7 @@
   "configuration.endpoints.models.capabilities.toolCalling.integer.description": "Maximum number of tools supported.",
   "configuration.endpoints.models.capabilities.imageInput.description": "Whether the model supports image input.",
   "configuration.endpoints.models.parallelToolCalling.description": "Enable or disable parallel tool calling (unset for provider default).",
+  "configuration.endpoints.models.omitToolsDefinition.description": "When enabled, omits the 'tools' block in outbound API calls. Useful for models that claim tool support but fail when sent tool definitions.",
   "configuration.endpoints.models.stream.description": "Whether to stream the response.",
   "configuration.endpoints.models.temperature.description": "Sampling temperature.",
   "configuration.endpoints.models.topK.description": "Top-k sampling.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -110,6 +110,7 @@
   "configuration.endpoints.models.capabilities.toolCalling.integer.description": "支持的最大工具数量。",
   "configuration.endpoints.models.capabilities.imageInput.description": "模型是否支持图像输入。",
   "configuration.endpoints.models.parallelToolCalling.description": "启用或禁用并行工具调用（不设置则使用供应商默认行为）。",
+  "configuration.endpoints.models.omitToolsDefinition.description": "启用时，在对外 API 调用中省略 'tools' 块。适用于声称支持工具但在收到工具定义时出错的模型。",
   "configuration.endpoints.models.stream.description": "是否以流式方式返回响应。",
   "configuration.endpoints.models.temperature.description": "采样温度。",
   "configuration.endpoints.models.topK.description": "Top-k 采样。",

--- a/src/client/anthropic/client.ts
+++ b/src/client/anthropic/client.ts
@@ -709,15 +709,6 @@ export class AnthropicProvider implements ApiProvider {
     const hasTools = (options.tools && options.tools.length > 0) ?? false;
     const stream = model.stream ?? true;
 
-    const anthropicInterleavedThinkingEnabled =
-      thinkingEnabled &&
-      hasTools &&
-      isFeatureSupported(
-        FeatureId.AnthropicInterleavedThinking,
-        this.config,
-        model,
-      );
-
     const {
       system,
       messages: anthropicMessages,
@@ -732,12 +723,23 @@ export class AnthropicProvider implements ApiProvider {
     // Also add tools if web search is enabled even without explicit tools
     const webSearchEnabled = model.webSearch?.enabled === true;
     const toolsResult =
-      hasTools || webSearchEnabled
-        ? this.convertTools(options.tools ?? [], model)
-        : undefined;
+      model.omitToolsDefinition === true
+        ? undefined
+        : hasTools || webSearchEnabled
+          ? this.convertTools(options.tools ?? [], model)
+          : undefined;
 
     const tools = toolsResult?.tools;
     const hasMemoryTool = toolsResult?.hasMemoryTool ?? false;
+
+    const anthropicInterleavedThinkingEnabled =
+      thinkingEnabled &&
+      (tools?.length ?? 0) > 0 &&
+      isFeatureSupported(
+        FeatureId.AnthropicInterleavedThinking,
+        this.config,
+        model,
+      );
 
     const fineGrainedToolStreamingEnabled =
       stream === true &&

--- a/src/client/google/ai-studio-client.ts
+++ b/src/client/google/ai-studio-client.ts
@@ -715,7 +715,10 @@ export class GoogleAIStudioProvider implements ApiProvider {
       sanitizedMessages,
       expectedIdentity,
     );
-    const tools = this.convertTools(options.tools);
+    const tools =
+      model.omitToolsDefinition === true
+        ? undefined
+        : this.convertTools(options.tools);
     const functionCallingConfig = this.buildFunctionCallingConfig(
       options.toolMode,
       tools,

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -844,7 +844,10 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       reasoningType,
       expectedIdentity,
     );
-    const tools = this.convertTools(options.tools, shouldApplyCacheControl);
+    const tools =
+      model.omitToolsDefinition === true
+        ? undefined
+        : this.convertTools(options.tools, shouldApplyCacheControl);
     const toolChoice = this.convertToolChoice(options.toolMode, tools);
     const streamEnabled = model.stream ?? true;
 

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -1049,7 +1049,10 @@ export class OpenAIResponsesProvider implements ApiProvider {
       sanitizedMessages,
       expectedIdentity,
     );
-    const tools = this.convertTools(options.tools);
+    const tools =
+      model.omitToolsDefinition === true
+        ? undefined
+        : this.convertTools(options.tools);
     const toolChoice = this.convertToolChoice(options.toolMode, tools);
     const streamEnabled = model.stream ?? true;
     const supportsPreviousResponseId =

--- a/src/config-ops.ts
+++ b/src/config-ops.ts
@@ -24,6 +24,7 @@ export const MODEL_CONFIG_KEYS = [
   'frequencyPenalty',
   'presencePenalty',
   'parallelToolCalling',
+  'omitToolsDefinition',
   'serviceTier',
   'verbosity',
   'thinking',

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,8 @@ export interface ModelConfig {
   presencePenalty?: number;
   /** Parallel tool calling (true to enable, false to disable, undefined to use default) */
   parallelToolCalling?: boolean;
+  /** Omit tools definition in API calls (true to enable, false to disable, undefined to use default) */
+  omitToolsDefinition?: boolean;
   /** Service tier / processing tier */
   serviceTier?: ServiceTier;
   /**

--- a/src/ui/model-fields.ts
+++ b/src/ui/model-fields.ts
@@ -287,6 +287,32 @@ export const modelFormSchema: FormSchema<ModelConfig> = {
             ? t('enable')
             : t('disable'),
     },
+    // Omit Tools Definition
+    {
+      key: 'omitToolsDefinition',
+      type: 'picker',
+      label: t('Omit Tools Definition'),
+      icon: 'exclude',
+      section: 'capabilities',
+      title: t('Omit Tools Definition'),
+      placeholder: t('Omit tools block in API calls'),
+      options: [
+        {
+          label: t('Disabled'),
+          description: t('Use model default behavior'),
+          value: undefined,
+        },
+        {
+          label: t('Enabled'),
+          description: t('Omit tools block in API calls'),
+          value: true,
+        },
+      ],
+      getDescription: (draft) =>
+        draft.omitToolsDefinition === true
+          ? t('Enabled')
+          : t('Disabled'),
+    },
     // Image Input (custom because it modifies capabilities nested object)
     {
       key: 'capabilities',


### PR DESCRIPTION
Add a new model configuration option that omits the 'tools' block in
outbound API calls when enabled. This is useful for models that claim
tool support but fail when sent tool definitions (e.g. iFlow - DeepSeek R1)

- Add omitToolsDefinition property to model config schema
- Add UI picker field for the option in model settings
- Implement tool omission logic in OpenAI, Anthropic, and Google clients
- Add localization strings (en/zh-cn)

Although tool calling can be disabled in the current model selector, VS Code hides
any models that do not have the tool capability when agent mode is enabled.
This feature allows a model to have a mock "tool" capability while stripping
the capability when the API request is sent to the provider.