### PR TITLE
fix: prevent context window overcalculation for Codex models

### DIFF
--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -306,14 +306,14 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
     _credential: AuthTokenInfo,
   ): Promise<ModelConfig[]> {
     return [
-      { id: 'gpt-5.1-codex-max', maxOutputTokens: undefined },
-      { id: 'gpt-5.1-codex-mini', maxOutputTokens: undefined },
-      { id: 'gpt-5.2', maxOutputTokens: undefined },
-      { id: 'gpt-5.4', maxOutputTokens: undefined },
-      { id: 'gpt-5.2-codex', maxOutputTokens: undefined },
-      { id: 'gpt-5.3-codex', maxOutputTokens: undefined },
-      { id: 'gpt-5.3-codex-spark', maxOutputTokens: undefined },
-      { id: 'gpt-5.1-codex', maxOutputTokens: undefined },
+      { id: 'gpt-5.1-codex-max', maxOutputTokens: 0 },
+      { id: 'gpt-5.1-codex-mini', maxOutputTokens: 0 },
+      { id: 'gpt-5.2', maxOutputTokens: 0 },
+      { id: 'gpt-5.4', maxOutputTokens: 0 },
+      { id: 'gpt-5.2-codex', maxOutputTokens: 0 },
+      { id: 'gpt-5.3-codex', maxOutputTokens: 0 },
+      { id: 'gpt-5.3-codex-spark', maxOutputTokens: 0 },
+      { id: 'gpt-5.1-codex', maxOutputTokens: 0 },
     ];
   }
 }

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -1078,7 +1078,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
       ...this.buildReasoningParams(model, useThinkingParam2),
       ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
       ...(model.verbosity ? { text: { verbosity: model.verbosity } } : {}),
-      ...(model.maxOutputTokens !== undefined
+      ...(model.maxOutputTokens !== undefined && model.maxOutputTokens !== 0
         ? { max_output_tokens: model.maxOutputTokens }
         : {}),
       ...(model.temperature !== undefined


### PR DESCRIPTION
When maxOutputTokens is undefined, VS Code's context calculation includes default output tokens in the context window count. By setting maxOutputTokens to 0 and excluding it from the API request, Codex models now correctly report available context without the default output token deduction.