### PR TITLE
feat: preserve Responses reasoning state and expose store flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,6 +348,10 @@
                 "type": "string",
                 "description": "%configuration.endpoints.baseUrl.description%"
               },
+              "store": {
+                "type": "boolean",
+                "description": "%configuration.endpoints.store.description%"
+              },
               "balanceProvider": {
                 "type": "object",
                 "description": "%configuration.endpoints.balanceProvider.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -50,6 +50,7 @@
   "configuration.endpoints.type.enumDescriptions.11": "Qwen Code",
   "configuration.endpoints.name.description": "Display name for this provider.",
   "configuration.endpoints.baseUrl.description": "API base URL (e.g., https://api.anthropic.com).",
+  "configuration.endpoints.store.description": "Whether to store responses on the provider side (OpenAI Responses `store` flag). For Codex, the default was false; set true to enable storing.",
   "configuration.endpoints.balanceProvider.description": "Provider balance monitoring configuration.",
   "configuration.endpoints.balanceProvider.method.none.description": "Disable balance monitoring.",
   "configuration.endpoints.balanceProvider.method.moonshot.description": "Use Moonshot AI balance monitor.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -50,6 +50,7 @@
   "configuration.endpoints.type.enumDescriptions.11": "Qwen Code",
   "configuration.endpoints.name.description": "此供应商的显示名称。",
   "configuration.endpoints.baseUrl.description": "API 基础 URL（例如：https://api.anthropic.com）。",
+  "configuration.endpoints.store.description": "是否在供应商侧存储响应（OpenAI Responses 的 `store` 参数）。Codex 之前默认是 false；设为 true 可启用存储。",
   "configuration.endpoints.balanceProvider.description": "供应商余额监控配置。",
   "configuration.endpoints.balanceProvider.method.none.description": "禁用余额监控。",
   "configuration.endpoints.balanceProvider.method.moonshot.description": "使用 Moonshot AI 余额监控。",

--- a/src/client/github-copilot/client.ts
+++ b/src/client/github-copilot/client.ts
@@ -20,7 +20,6 @@ import { OpenAIChatCompletionProvider } from '../openai/chat-completion-client';
 import { OpenAIResponsesProvider } from '../openai/responses-client';
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
-import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 import { buildOpencodeUserAgent } from '../../utils';
 
 function resolveCopilotApiBaseUrl(config: ProviderConfig): string {
@@ -230,14 +229,6 @@ class GitHubCopilotChatCompletionProvider extends OpenAIChatCompletionProvider {
 class GitHubCopilotResponsesProvider extends OpenAIResponsesProvider {
   protected override resolveBaseUrl(config: ProviderConfig): string {
     return resolveCopilotApiBaseUrl(config);
-  }
-
-  protected override handleRequest(
-    sessionId: string,
-    baseBody: ResponseCreateParamsBase,
-  ): void {
-    super.handleRequest(sessionId, baseBody);
-    baseBody.store ??= false;
   }
 
   protected override buildHeaders(

--- a/src/client/github-copilot/client.ts
+++ b/src/client/github-copilot/client.ts
@@ -20,6 +20,7 @@ import { OpenAIChatCompletionProvider } from '../openai/chat-completion-client';
 import { OpenAIResponsesProvider } from '../openai/responses-client';
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
+import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 import { buildOpencodeUserAgent } from '../../utils';
 
 function resolveCopilotApiBaseUrl(config: ProviderConfig): string {
@@ -231,6 +232,14 @@ class GitHubCopilotResponsesProvider extends OpenAIResponsesProvider {
     return resolveCopilotApiBaseUrl(config);
   }
 
+  protected override handleRequest(
+    sessionId: string,
+    baseBody: ResponseCreateParamsBase,
+  ): void {
+    super.handleRequest(sessionId, baseBody);
+    baseBody.store ??= false;
+  }
+
   protected override buildHeaders(
     sessionId: string,
     credential?: AuthTokenInfo,
@@ -263,7 +272,9 @@ export class GitHubCopilotProvider implements ApiProvider {
 
   constructor(config: ProviderConfig) {
     const extraBody = config.extraBody ?? {};
-    const hasStore = Object.prototype.hasOwnProperty.call(extraBody, 'store');
+    const hasStore =
+      config.store !== undefined ||
+      Object.prototype.hasOwnProperty.call(extraBody, 'store');
     const configWithDefaults: ProviderConfig = hasStore
       ? config
       : { ...config, extraBody: { ...extraBody, store: false } };

--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -220,11 +220,10 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
     sessionId: string,
     baseBody: ResponseCreateParamsBase,
   ): void {
-    Object.assign(baseBody, {
-      store: false,
-      prompt_cache_key: sessionId,
-      instructions: '',
-    });
+    super.handleRequest(sessionId, baseBody);
+    baseBody.store ??= false;
+    baseBody.prompt_cache_key = sessionId;
+    baseBody.instructions = '';
   }
 
   protected override createClient(

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -6,6 +6,7 @@ import {
 import { createSimpleHttpLogger } from '../../logger';
 import type { ProviderHttpLogger, RequestLogger } from '../../logger';
 import {
+  ENCRYPTED_THINKING_PLACEHOLDER,
   ThinkingBlockMetadata,
 } from '../types';
 import { FeatureId } from '../definitions';
@@ -126,7 +127,7 @@ type OpenAIResponsesRequestContext = {
   imageGenerationOutputMimeType: string;
 };
 
-type ResponseThinkingContentType = 'summary' | 'content';
+type ResponseThinkingContentType = 'encrypted' | 'summary' | 'content';
 
 type ResponseThinkingOutputState = {
   lastType?: ResponseThinkingContentType;
@@ -1795,28 +1796,22 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
     const prefix =
       state.lastType !== undefined && state.lastType !== type ? '\n' : '';
-    const output = prefix + text;
+    const output =
+      prefix + (type === 'encrypted' ? ENCRYPTED_THINKING_PLACEHOLDER : text);
 
     if (emitMode !== 'metadata-only') {
       yield new vscode.LanguageModelThinkingPart(output);
     }
 
     if (metadata) {
-      metadata._completeThinking = (metadata._completeThinking || '') + text;
+      if (type === 'encrypted') {
+        metadata.redactedData = text;
+      } else {
+        metadata._completeThinking = (metadata._completeThinking || '') + text;
+      }
     }
 
     state.lastType = type;
-  }
-
-  private setEncryptedThinkingMetadata(
-    encryptedContent: string,
-    metadata: OpenAIResponsesThinkingMetadata | undefined,
-  ): void {
-    if (!encryptedContent || !metadata) {
-      return;
-    }
-
-    metadata.redactedData = encryptedContent;
   }
 
   private appendThinkingMetadata(
@@ -1884,7 +1879,13 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
     for (const reasoning of reasonings) {
       if (reasoning.encrypted_content) {
-        this.setEncryptedThinkingMetadata(reasoning.encrypted_content, metadata);
+        yield* this.emitThinkingText(
+          'encrypted',
+          reasoning.encrypted_content,
+          emitMode,
+          metadata,
+          state,
+        );
       }
 
       for (const part of reasoning.summary) {
@@ -2030,6 +2031,15 @@ export class OpenAIResponsesProvider implements ApiProvider {
       switch (event.type) {
         case 'response.output_item.added':
           addedOutputItems.set(event.output_index, event.item);
+          if (event.item.type === 'reasoning' && event.item.encrypted_content) {
+            yield* this.emitThinkingText(
+              'encrypted',
+              event.item.encrypted_content,
+              'content-only',
+              undefined,
+              thinkingOutputState,
+            );
+          }
           break;
 
         case 'response.output_text.delta':

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -6,7 +6,6 @@ import {
 import { createSimpleHttpLogger } from '../../logger';
 import type { ProviderHttpLogger, RequestLogger } from '../../logger';
 import {
-  ENCRYPTED_THINKING_PLACEHOLDER,
   ThinkingBlockMetadata,
 } from '../types';
 import { FeatureId } from '../definitions';
@@ -127,10 +126,14 @@ type OpenAIResponsesRequestContext = {
   imageGenerationOutputMimeType: string;
 };
 
-type ResponseThinkingContentType = 'encrypted' | 'summary' | 'content';
+type ResponseThinkingContentType = 'summary' | 'content';
 
 type ResponseThinkingOutputState = {
   lastType?: ResponseThinkingContentType;
+};
+
+type OpenAIResponsesThinkingMetadata = ThinkingBlockMetadata & {
+  rawState?: OpenAIResponsesMarkerData;
 };
 
 type ResponseImageGenerationCall = Extract<
@@ -352,6 +355,10 @@ export class OpenAIResponsesProvider implements ApiProvider {
     return payload;
   }
 
+  protected shouldRenderReasoningContent(): boolean {
+    return true;
+  }
+
   protected getInputMessageRole(
     role: vscode.LanguageModelChatMessageRole,
   ): EasyInputMessage['role'] {
@@ -452,6 +459,36 @@ export class OpenAIResponsesProvider implements ApiProvider {
               } catch {
                 // fall back to best-effort conversion
               }
+            }
+
+            const thinkingRawState = this.extractThinkingRawState(
+              msg.content,
+              expectedIdentity,
+            );
+            if (thinkingRawState) {
+              if (firstSessionId == null && thinkingRawState.sessionId) {
+                firstSessionId = thinkingRawState.sessionId;
+              }
+              if (
+                typeof thinkingRawState.responseId === 'string' &&
+                thinkingRawState.responseId.trim()
+              ) {
+                latestResponseId = thinkingRawState.responseId;
+                latestResponseBoundaryIndex =
+                  messageOriginIndexes?.[messageIndex] ?? messageIndex;
+                outItemsAfterLatestResponse = [];
+              } else {
+                latestResponseId = undefined;
+                latestResponseBoundaryIndex = undefined;
+                outItemsAfterLatestResponse = [];
+              }
+              const item: EasyInputMessage = {
+                role: 'assistant',
+                content: '',
+              };
+              rawMap.set(item, thinkingRawState.data);
+              outItems.push(item);
+              break;
             }
 
             for (const part of msg.content) {
@@ -809,7 +846,12 @@ export class OpenAIResponsesProvider implements ApiProvider {
   protected handleRequest(
     sessionId: string,
     baseBody: ResponseCreateParamsBase,
-  ) {}
+  ): void {
+    const storeOverride = this.config.store;
+    if (storeOverride !== undefined) {
+      baseBody.store = storeOverride;
+    }
+  }
 
   private resolveTransportMode(streamEnabled: boolean): ResolvedTransportMode {
     switch (this.config.transport) {
@@ -1613,7 +1655,22 @@ export class OpenAIResponsesProvider implements ApiProvider {
       (v): v is ResponseReasoningItem => v.type === 'reasoning',
     );
 
-    yield* this.extractThinkingParts(reasonings);
+    const markerData: OpenAIResponsesMarkerData = {
+      data: message.output,
+      identity: expectedIdentity,
+      sessionId,
+    };
+    if (includeResponseIdInMarker) {
+      markerData.responseId = message.id;
+    }
+
+    yield* this.extractThinkingParts(
+      reasonings,
+      'full',
+      undefined,
+      undefined,
+      markerData,
+    );
 
     for (const item of message.output) {
       switch (item.type) {
@@ -1662,13 +1719,6 @@ export class OpenAIResponsesProvider implements ApiProvider {
       }
     }
 
-    const markerData: OpenAIResponsesMarkerData = {
-      data: message.output,
-      sessionId,
-    };
-    if (includeResponseIdInMarker) {
-      markerData.responseId = message.id;
-    }
     yield encodeStatefulMarkerPart<OpenAIResponsesMarkerData>(
       expectedIdentity,
       markerData,
@@ -1736,7 +1786,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
     type: ResponseThinkingContentType,
     text: string,
     emitMode: 'full' | 'metadata-only' | 'content-only',
-    metadata: ThinkingBlockMetadata | undefined,
+    metadata: OpenAIResponsesThinkingMetadata | undefined,
     state: ResponseThinkingOutputState,
   ): Generator<vscode.LanguageModelThinkingPart> {
     if (!text) {
@@ -1745,43 +1795,96 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
     const prefix =
       state.lastType !== undefined && state.lastType !== type ? '\n' : '';
-    const output =
-      prefix + (type === 'encrypted' ? ENCRYPTED_THINKING_PLACEHOLDER : text);
+    const output = prefix + text;
 
     if (emitMode !== 'metadata-only') {
       yield new vscode.LanguageModelThinkingPart(output);
     }
 
     if (metadata) {
-      if (type === 'encrypted') {
-        metadata.redactedData = text;
-      } else {
-        metadata._completeThinking = (metadata._completeThinking || '') + text;
-      }
+      metadata._completeThinking = (metadata._completeThinking || '') + text;
     }
 
     state.lastType = type;
   }
 
+  private setEncryptedThinkingMetadata(
+    encryptedContent: string,
+    metadata: OpenAIResponsesThinkingMetadata | undefined,
+  ): void {
+    if (!encryptedContent || !metadata) {
+      return;
+    }
+
+    metadata.redactedData = encryptedContent;
+  }
+
+  private appendThinkingMetadata(
+    text: string,
+    metadata: OpenAIResponsesThinkingMetadata | undefined,
+  ): void {
+    if (!text || !metadata) {
+      return;
+    }
+
+    metadata._completeThinking = (metadata._completeThinking || '') + text;
+  }
+
+  private applyThinkingRawState(
+    metadata: OpenAIResponsesThinkingMetadata | undefined,
+    rawState: OpenAIResponsesMarkerData | undefined,
+  ): void {
+    if (!metadata || !rawState) {
+      return;
+    }
+
+    metadata.rawState = rawState;
+  }
+
+  private extractThinkingRawState(
+    parts: readonly unknown[],
+    expectedIdentity?: string,
+  ): OpenAIResponsesMarkerData | undefined {
+    for (const part of parts) {
+      if (!(part instanceof vscode.LanguageModelThinkingPart)) {
+        continue;
+      }
+
+      const metadata = part.metadata as OpenAIResponsesThinkingMetadata | undefined;
+      const rawState = metadata?.rawState;
+      if (
+        rawState &&
+        Array.isArray(rawState.data) &&
+        (expectedIdentity === undefined ||
+          rawState.identity === undefined ||
+          rawState.identity === expectedIdentity) &&
+        rawState.data.every(
+          (item) => typeof item === 'object' && item !== null && 'type' in item,
+        )
+      ) {
+        return rawState;
+      }
+    }
+
+    return undefined;
+  }
+
   private *extractThinkingParts(
     reasonings: readonly ResponseReasoningItem[],
     emitMode: 'full' | 'metadata-only' | 'content-only' = 'full',
-    metadata?: ThinkingBlockMetadata,
+    metadata?: OpenAIResponsesThinkingMetadata,
     state: ResponseThinkingOutputState = {},
+    rawState?: OpenAIResponsesMarkerData,
   ): Generator<vscode.LanguageModelThinkingPart> {
     if (emitMode !== 'content-only' && metadata == null) {
       metadata = {};
     }
 
+    this.applyThinkingRawState(metadata, rawState);
+
     for (const reasoning of reasonings) {
       if (reasoning.encrypted_content) {
-        yield* this.emitThinkingText(
-          'encrypted',
-          reasoning.encrypted_content,
-          emitMode,
-          metadata,
-          state,
-        );
+        this.setEncryptedThinkingMetadata(reasoning.encrypted_content, metadata);
       }
 
       for (const part of reasoning.summary) {
@@ -1798,13 +1901,17 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
       for (const part of reasoning.content ?? []) {
         if (part.type === 'reasoning_text') {
-          yield* this.emitThinkingText(
-            'content',
-            part.text,
-            emitMode,
-            metadata,
-            state,
-          );
+          if (this.shouldRenderReasoningContent()) {
+            yield* this.emitThinkingText(
+              'content',
+              part.text,
+              emitMode,
+              metadata,
+              state,
+            );
+          } else {
+            this.appendThinkingMetadata(part.text, metadata);
+          }
         }
       }
     }
@@ -1923,15 +2030,6 @@ export class OpenAIResponsesProvider implements ApiProvider {
       switch (event.type) {
         case 'response.output_item.added':
           addedOutputItems.set(event.output_index, event.item);
-          if (event.item.type === 'reasoning' && event.item.encrypted_content) {
-            yield* this.emitThinkingText(
-              'encrypted',
-              event.item.encrypted_content,
-              'content-only',
-              undefined,
-              thinkingOutputState,
-            );
-          }
           break;
 
         case 'response.output_text.delta':
@@ -1947,7 +2045,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
           break;
 
         case 'response.reasoning_text.delta':
-          if (event.delta) {
+          if (event.delta && this.shouldRenderReasoningContent()) {
             yield* this.emitThinkingText(
               'content',
               event.delta,
@@ -2015,15 +2113,23 @@ export class OpenAIResponsesProvider implements ApiProvider {
             (v): v is ResponseReasoningItem => v.type === 'reasoning',
           );
 
-          yield* this.extractThinkingParts(reasonings, 'metadata-only');
-
           const markerData: OpenAIResponsesMarkerData = {
             data: completedOutput,
+            identity: expectedIdentity,
             sessionId,
           };
           if (includeResponseIdInMarker) {
             markerData.responseId = response.id;
           }
+
+          yield* this.extractThinkingParts(
+            reasonings,
+            'metadata-only',
+            undefined,
+            undefined,
+            markerData,
+          );
+
           yield encodeStatefulMarkerPart<OpenAIResponsesMarkerData>(
             expectedIdentity,
             markerData,
@@ -2141,6 +2247,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
 export type OpenAIResponsesMarkerData = {
   /** Raw `response.output` items, preserved verbatim for follow-up requests. */
   data: ResponseOutputItem[];
+  identity?: string;
   sessionId?: string;
   responseId?: string;
 };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -45,6 +45,11 @@ export interface ThinkingBlockMetadata {
    * VSCode use this.
    */
   _completeThinking?: string;
+
+  /**
+   * Provider-specific raw response state used to restore reasoning across turns.
+   */
+  rawState?: unknown;
 }
 
 export const ENCRYPTED_THINKING_PLACEHOLDER = 'Encrypted thinking...';

--- a/src/config-ops.ts
+++ b/src/config-ops.ts
@@ -62,6 +62,7 @@ export const PROVIDER_CONFIG_KEYS = [
   'models',
   'extraHeaders',
   'extraBody',
+  'store',
   'timeout',
   'retry',
   'autoFetchOfficialModels',

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,11 @@ export interface ProviderConfig {
   extraHeaders?: Record<string, string>;
   /** Extra body parameters to include in requests */
   extraBody?: Record<string, unknown>;
+  /**
+   * Responses API store flag. When set, overrides the provider default.
+   * Codex previously forced `store: false`; set this to true to enable storing.
+   */
+  store?: boolean;
   /** Timeout configuration */
   timeout?: TimeoutConfig;
   /** Retry configuration */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
-import { DataPartMimeTypes, StatefulMarkerData } from './client/types';
+import {
+  DataPartMimeTypes,
+  StatefulMarkerData,
+  type ThinkingBlockMetadata,
+} from './client/types';
 import type { ProviderHttpLogger } from './logger';
 import { officialModelsManager } from './official-models-manager';
 import type {
@@ -1237,6 +1241,28 @@ function collectToolResultIds(
   );
 }
 
+function hasMatchingThinkingRawState(
+  message: vscode.LanguageModelChatRequestMessage,
+  expectedIdentity: string,
+): boolean {
+  if (message.role !== vscode.LanguageModelChatMessageRole.Assistant) {
+    return false;
+  }
+
+  return message.content.some((part) => {
+    if (!(part instanceof vscode.LanguageModelThinkingPart)) {
+      return false;
+    }
+
+    const metadata = part.metadata as ThinkingBlockMetadata | undefined;
+    if (!metadata || !isRecord(metadata.rawState)) {
+      return false;
+    }
+
+    return metadata.rawState['identity'] === expectedIdentity;
+  });
+}
+
 function sanitizeMessageForModelSwitch(
   message: vscode.LanguageModelChatRequestMessage,
   imageRetention: SanitizedImagePartRetention,
@@ -1361,6 +1387,11 @@ export function sanitizeMessagesForModelSwitchDetailed(
           continue;
         }
 
+        const hasTrustedThinkingRawState = hasMatchingThinkingRawState(
+          message,
+          options.expectedIdentity,
+        );
+
         const markerParts = message.content.filter(
           (part): part is vscode.LanguageModelDataPart =>
             part instanceof vscode.LanguageModelDataPart &&
@@ -1368,8 +1399,11 @@ export function sanitizeMessagesForModelSwitchDetailed(
         );
 
         if (markerParts.length !== 1) {
-          isRoundValid = false;
-          break;
+          if (!hasTrustedThinkingRawState) {
+            isRoundValid = false;
+            break;
+          }
+          continue;
         }
 
         const decoded = tryDecodeStatefulMarkerPart<object>(
@@ -1377,7 +1411,7 @@ export function sanitizeMessagesForModelSwitchDetailed(
           options.modelId,
           markerParts[0],
         );
-        if (!decoded) {
+        if (!decoded && !hasTrustedThinkingRawState) {
           isRoundValid = false;
           break;
         }


### PR DESCRIPTION
## Summary
- add a provider-level `store` option and pass it through the OpenAI Responses request path so Responses, Codex, and GitHub Copilot can override the provider default instead of always forcing `store: false`
- preserve raw Responses reasoning output in thinking metadata so follow-up turns and model-switch sanitization can recover provider state even when a stateful marker part is missing
- stop rendering encrypted reasoning placeholders while still retaining the encrypted/redacted payload in thinking metadata for restoration

## Testing
- `npm run compile`