### PR TITLE
fix: Antigravity directly rejecting requests due to extraneous fields like enumDescriptions in the tool parameter JSON Schema

### DIFF
--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -408,7 +408,6 @@ function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
     'readOnly',
     'writeOnly',
     'deprecated',
-    // VS Code / JSON schema UI annotations that Antigravity does not accept.
     'enumDescriptions',
     'markdownEnumDescriptions',
     'markdownDescription',

--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -408,6 +408,12 @@ function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
     'readOnly',
     'writeOnly',
     'deprecated',
+    // VS Code / JSON schema UI annotations that Antigravity does not accept.
+    'enumDescriptions',
+    'markdownEnumDescriptions',
+    'markdownDescription',
+    'deprecationMessage',
+    'errorMessage',
   ]);
 
   const appendHintToDescription = (


### PR DESCRIPTION
#116 Fixed the issue where Antigravity outright rejected requests because fields such as enumDescriptions were mixed into the tool parameter JSON Schema.