### PR TITLE
Fix Codex reasoning summary display

### DIFF
--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -28,6 +28,14 @@ const CODEX_COMMON_REQUEST_FIELDS_TO_DELETE = [
   'safety_identifier',
   'stream_options',
 ] as const;
+const CODEX_REASONING_SUMMARY_DEFAULTS = {
+  maxOutputTokens: undefined,
+  thinking: {
+    type: 'enabled',
+    effort: 'xhigh',
+    summary: 'auto',
+  },
+} satisfies Pick<ModelConfig, 'maxOutputTokens' | 'thinking'>;
 
 type CodexResponseTool = NonNullable<ResponseCreateParamsBase['tools']>[number];
 type CodexImageGenerationTool = Extract<
@@ -385,12 +393,16 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
     _credential: AuthTokenInfo,
   ): Promise<ModelConfig[]> {
     return [
-      { id: 'gpt-5.5', maxInputTokens: 400000, maxOutputTokens: undefined },
-      { id: 'gpt-5.4', maxOutputTokens: undefined },
-      { id: 'gpt-5.2', maxOutputTokens: undefined },
-      { id: 'gpt-5.4-mini', maxOutputTokens: undefined },
-      { id: 'gpt-5.3-codex', maxOutputTokens: undefined },
-      { id: 'gpt-5.3-codex-spark', maxOutputTokens: undefined },
+      {
+        id: 'gpt-5.5',
+        maxInputTokens: 400000,
+        ...CODEX_REASONING_SUMMARY_DEFAULTS,
+      },
+      { id: 'gpt-5.4', ...CODEX_REASONING_SUMMARY_DEFAULTS },
+      { id: 'gpt-5.2', ...CODEX_REASONING_SUMMARY_DEFAULTS },
+      { id: 'gpt-5.4-mini', ...CODEX_REASONING_SUMMARY_DEFAULTS },
+      { id: 'gpt-5.3-codex', ...CODEX_REASONING_SUMMARY_DEFAULTS },
+      { id: 'gpt-5.3-codex-spark', ...CODEX_REASONING_SUMMARY_DEFAULTS },
     ];
   }
 }

--- a/src/well-known/models.ts
+++ b/src/well-known/models.ts
@@ -1,4 +1,9 @@
-import type { ModelConfig, ProviderConfig, ThinkingEffort } from '../types';
+import type {
+  ModelConfig,
+  PresetTemplate,
+  ProviderConfig,
+  ThinkingEffort,
+} from '../types';
 import type { ProviderPattern } from '../client/types';
 import { matchProvider } from '../client/utils';
 import {
@@ -102,9 +107,7 @@ function anthropicAdaptiveReasoningEffort<T extends readonly ThinkingEffort[]>(
   });
 }
 
-function withThinkingSummaryAuto(
-  template: ReturnType<typeof adaptiveReasoningEffort>,
-): ReturnType<typeof adaptiveReasoningEffort> {
+function withThinkingSummaryAuto(template: PresetTemplate): PresetTemplate {
   return {
     ...template,
     presets: template.presets.map((preset) => ({
@@ -817,6 +820,7 @@ const _WELL_KNOWN_MODELS = [
     thinking: {
       type: 'enabled',
       effort: 'xhigh',
+      summary: 'auto',
     },
     capabilities: {
       toolCalling: true,
@@ -824,7 +828,9 @@ const _WELL_KNOWN_MODELS = [
       editTools: 'apply-patch',
     },
     presetTemplates: [
-      openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      withThinkingSummaryAuto(
+        openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      ),
     ],
   },
   {
@@ -845,6 +851,7 @@ const _WELL_KNOWN_MODELS = [
     thinking: {
       type: 'enabled',
       effort: 'xhigh',
+      summary: 'auto',
     },
     capabilities: {
       toolCalling: true,
@@ -852,7 +859,9 @@ const _WELL_KNOWN_MODELS = [
       editTools: 'apply-patch',
     },
     presetTemplates: [
-      openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      withThinkingSummaryAuto(
+        openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      ),
     ],
   },
   {
@@ -865,6 +874,7 @@ const _WELL_KNOWN_MODELS = [
     thinking: {
       type: 'enabled',
       effort: 'xhigh',
+      summary: 'auto',
     },
     capabilities: {
       toolCalling: true,
@@ -872,7 +882,9 @@ const _WELL_KNOWN_MODELS = [
       editTools: 'apply-patch',
     },
     presetTemplates: [
-      openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      withThinkingSummaryAuto(
+        openAiReasoningEffort(OPENAI_CODEX_REASONING_EFFORTS, 'xhigh'),
+      ),
     ],
   },
   {


### PR DESCRIPTION
## Summary
- request `reasoning.summary: 'auto'` for built-in Codex models and Codex auto-discovered models
- keep preset reasoning-effort selections for Codex models carrying the summary request
- leave OpenAI Responses encrypted thinking placeholder rendering unchanged

Fixes #154

## Validation
- `npm run compile`
- `git diff --check`
