### PR TITLE
fix: strip non-standard JSON Schema fields in normalizeToolSchemaValue (OpenAI-compatible path)

### DIFF
--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -469,6 +469,27 @@ export function parseToolArguments(
   }
 }
 
+/**
+ * VS Code / OpenAI-specific non-standard JSON Schema annotation fields that
+ * cause 400 errors on strict API backends (e.g. Gemini's protobuf validation
+ * rejects unknown fields like "enumDescriptions").
+ *
+ * Note: cleanJsonSchemaForAntigravity has its own broader droppedKeys set
+ * that also covers standard-but-unsupported fields like $schema, title, etc.
+ * This set only targets the non-standard VS Code UI annotation fields.
+ */
+const NON_STANDARD_SCHEMA_KEYS: ReadonlySet<string> = new Set([
+  'enumDescriptions',
+  'markdownEnumDescriptions',
+  'markdownDescription',
+  'deprecationMessage',
+  'errorMessage',
+  'patternErrorMessage',
+  'defaultSnippets',
+  'enumItemLabels',
+  'doNotSuggest',
+]);
+
 function isToolSchemaRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -781,22 +802,6 @@ function normalizeToolSchemaValue(value: unknown): unknown {
       simplifyToolSchemaUnion(base, variants, unionKey),
     );
   }
-
-  // Strip VS Code / OpenAI-specific non-standard JSON Schema annotation fields
-  // that cause 400 errors on strict API backends (e.g. Gemini's protobuf
-  // validation rejects unknown fields like "enumDescriptions").
-  // Aligned with the droppedKeys set in cleanJsonSchemaForAntigravity.
-  const NON_STANDARD_SCHEMA_KEYS: ReadonlySet<string> = new Set([
-    'enumDescriptions',
-    'markdownEnumDescriptions',
-    'markdownDescription',
-    'deprecationMessage',
-    'errorMessage',
-    'patternErrorMessage',
-    'defaultSnippets',
-    'enumItemLabels',
-    'doNotSuggest',
-  ]);
 
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -782,8 +782,27 @@ function normalizeToolSchemaValue(value: unknown): unknown {
     );
   }
 
+  // Strip VS Code / OpenAI-specific non-standard JSON Schema annotation fields
+  // that cause 400 errors on strict API backends (e.g. Gemini's protobuf
+  // validation rejects unknown fields like "enumDescriptions").
+  // Aligned with the droppedKeys set in cleanJsonSchemaForAntigravity.
+  const NON_STANDARD_SCHEMA_KEYS: ReadonlySet<string> = new Set([
+    'enumDescriptions',
+    'markdownEnumDescriptions',
+    'markdownDescription',
+    'deprecationMessage',
+    'errorMessage',
+    'patternErrorMessage',
+    'defaultSnippets',
+    'enumItemLabels',
+    'doNotSuggest',
+  ]);
+
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {
+    if (NON_STANDARD_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
     out[key] = normalizeToolSchemaValue(child);
   }
 


### PR DESCRIPTION
## Problem

When accessing Gemini via the **OpenAI Chat Completion compatible endpoint**, VS Code annotation fields like `enumDescriptions` in the tool parameter JSON Schema cause a 400 error:

```
Invalid JSON payload received. Unknown name "enumDescriptions" at
'request.tools[0].function_declarations[53].parameters.properties[3].value':
Cannot find field.

at OpenAIChatCompletionProvider.streamChat
```

Reported in #160. This is the same class of issue as #116, but on a **different code path**.

## Root Cause

PR #122 fixed `cleanJsonSchemaForAntigravity` in `code-assist-client.ts` (native Gemini path), but the shared `normalizeToolSchemaValue` in `utils.ts` (used by `OpenAIChatCompletionProvider`, `OllamaProvider`, `OpenAIResponsesProvider`, etc.) still passes these non-standard fields through without filtering.

When Gemini's OpenAI-compatible endpoint internally converts `tools[].function.parameters` to native `function_declarations[].parameters`, protobuf validation rejects the unknown fields.

| Path | Sanitizer | Filters enumDescriptions |
|------|-----------|-------------------------|
| Antigravity native | `cleanJsonSchemaForAntigravity` (code-assist-client.ts) | ✅ Fixed in #122 |
| OpenAI-compatible | `normalizeToolSchemaValue` (utils.ts) | ❌ **Not filtered** |

## Fix

Add a `NON_STANDARD_SCHEMA_KEYS` filter in `normalizeToolSchemaValue` to strip VS Code/JSON Schema annotation fields that are not part of the standard JSON Schema spec and cause errors on strict API backends.

This is a subset of the broader `droppedKeys` set used by `cleanJsonSchemaForAntigravity` — only the non-standard VS Code UI annotation fields are stripped here, since the OpenAI-compatible path must preserve standard JSON Schema fields like `$schema`, `title`, etc.

## Changes

- `src/client/utils.ts`: Add filtering of 9 non-standard JSON Schema keys in `normalizeToolSchemaValue`
- Hoisted `NON_STANDARD_SCHEMA_KEYS` to module scope (per Copilot review feedback)

## Closes

Closes #160
