### PR TITLE
fix: retry transient socket-close chat streams

### DIFF
--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_CHAT_RETRY_CONFIG,
   describeNetworkError,
   isAbortLikeError,
+  isRetryableNetworkError,
   isRetryableStatusCode,
   resolveChatNetwork,
   sanitizeMessagesForModelSwitch,
@@ -194,65 +195,6 @@ function calculateBackoffDelay(
   const jitterRange = cappedDelay * config.jitterFactor;
   const jitter = (Math.random() * 2 - 1) * jitterRange;
   return Math.round(cappedDelay + jitter);
-}
-
-function isRetryableNetworkError(error: unknown): boolean {
-  const retryableCodes = new Set<string>([
-    'ECONNRESET',
-    'ETIMEDOUT',
-    'ECONNREFUSED',
-    'EAI_AGAIN',
-    'ENOTFOUND',
-    // undici / fetch (Node) internal error codes
-    'UND_ERR_CONNECT_TIMEOUT',
-    'UND_ERR_HEADERS_TIMEOUT',
-    'UND_ERR_BODY_TIMEOUT',
-    'UND_ERR_SOCKET',
-  ]);
-
-  const hasCause = (value: unknown): value is { cause: unknown } =>
-    typeof value === 'object' && value !== null && 'cause' in value;
-
-  const tryGetErrorCode = (value: unknown): string | undefined => {
-    if (typeof value !== 'object' || value === null) {
-      return undefined;
-    }
-    if (!('code' in value)) {
-      return undefined;
-    }
-    const code = (value as { code: unknown }).code;
-    return typeof code === 'string' ? code : undefined;
-  };
-
-  if (!error) {
-    return false;
-  }
-
-  const directCode = tryGetErrorCode(error);
-  if (directCode && retryableCodes.has(directCode)) {
-    return true;
-  }
-
-  if (hasCause(error)) {
-    const causeCode = tryGetErrorCode(error.cause);
-    if (causeCode && retryableCodes.has(causeCode)) {
-      return true;
-    }
-  }
-
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
-    if (
-      message.includes('connection timeout') ||
-      message.includes('fetch failed') ||
-      message.includes('network error') ||
-      message.includes('socket hang up')
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function hashConversationSeed(seed: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,11 +16,13 @@ import {
 } from './ui/form-utils';
 import {
   calculateBackoffDelay,
+  describeNetworkError,
   delay,
   getAllModelsForProvider,
   getAllModelsForProviderSync,
   isAbortLikeError,
   isPlaceholderModelId,
+  isRetryableNetworkError,
   resolveMeaningfulError,
   resolveChatNetwork,
 } from './utils';
@@ -555,6 +557,27 @@ export class UnifyChatService implements vscode.LanguageModelChatProvider {
             if (token.isCancellationRequested && isAbortLikeError(error)) {
               // User cancelled the request; treat provider abort errors as expected.
               outcome = 'cancelled';
+            } else if (
+              partCount === 0 &&
+              !token.isCancellationRequested &&
+              isRetryableNetworkError(error) &&
+              emptyStreamAttempt < retryConfig.maxRetries
+            ) {
+              const delayMs = calculateBackoffDelay(
+                emptyStreamAttempt,
+                retryConfig,
+              );
+              logger.retry(
+                emptyStreamAttempt + 1,
+                retryConfig.maxRetries,
+                0,
+                delayMs,
+                undefined,
+                describeNetworkError(error),
+              );
+              await delay(delayMs, retryAbortController.signal);
+              emptyStreamAttempt++;
+              continue;
             } else {
               outcome = 'error';
               const normalizedError = resolveMeaningfulError(error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -493,16 +493,91 @@ function tryGetErrorCode(value: unknown): string | undefined {
   return typeof code === 'string' ? code : undefined;
 }
 
+function hasErrorCause(value: unknown): value is { cause: unknown } {
+  return typeof value === 'object' && value !== null && 'cause' in value;
+}
+
 function getErrorCode(error: unknown): string | undefined {
-  const direct = tryGetErrorCode(error);
-  if (direct) {
-    return direct;
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current && !seen.has(current)) {
+    seen.add(current);
+
+    const code = tryGetErrorCode(current);
+    if (code) {
+      return code;
+    }
+
+    if (!hasErrorCause(current)) {
+      break;
+    }
+
+    current = current.cause;
   }
-  if (typeof error === 'object' && error !== null && 'cause' in error) {
-    return tryGetErrorCode((error as { cause: unknown }).cause);
-  }
+
   return undefined;
 }
+
+function tryGetErrorMessage(value: unknown): string | undefined {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+  if (!('message' in value)) {
+    return undefined;
+  }
+  const message = (value as { message: unknown }).message;
+  return typeof message === 'string' ? message : undefined;
+}
+
+function hasRetryableNetworkErrorMessageText(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  return (
+    normalizedMessage.includes('fetch failed') ||
+    normalizedMessage.includes('network error') ||
+    normalizedMessage.includes('connection timeout') ||
+    normalizedMessage.includes('socket hang up') ||
+    normalizedMessage.includes('other side closed')
+  );
+}
+
+function hasRetryableNetworkErrorMessage(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current && !seen.has(current)) {
+    seen.add(current);
+
+    const message = tryGetErrorMessage(current);
+    if (message && hasRetryableNetworkErrorMessageText(message)) {
+      return true;
+    }
+
+    if (!hasErrorCause(current)) {
+      break;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
+}
+
+const RETRYABLE_NETWORK_ERROR_CODES = new Set<string>([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  // undici / fetch (Node) internal error codes
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
 
 const ABORT_LIKE_ERROR_CODES = new Set<string>([
   'ABORT_ERR',
@@ -715,6 +790,27 @@ export function describeNetworkError(error: unknown): string {
     return `${code}: ${message}`;
   }
   return message;
+}
+
+export function isRetryableNetworkError(
+  error: unknown,
+  options: { timedOut?: boolean } = {},
+): boolean {
+  if (!error) {
+    return false;
+  }
+
+  // Retry on our own connection-timeout aborts (may surface as AbortError).
+  if (options.timedOut && isAbortError(error)) {
+    return true;
+  }
+
+  const code = getErrorCode(error);
+  if (code && RETRYABLE_NETWORK_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  return hasRetryableNetworkErrorMessage(error);
 }
 
 /**
@@ -1272,72 +1368,6 @@ export async function fetchWithRetryUsingFetch(
   let lastError: Error | undefined;
   let attempt = 0;
 
-  const hasCause = (value: unknown): value is { cause: unknown } =>
-    typeof value === 'object' && value !== null && 'cause' in value;
-
-  const tryGetErrorCode = (value: unknown): string | undefined => {
-    if (typeof value !== 'object' || value === null) {
-      return undefined;
-    }
-    if (!('code' in value)) {
-      return undefined;
-    }
-    const code = (value as { code: unknown }).code;
-    return typeof code === 'string' ? code : undefined;
-  };
-
-  const retryableCodes = new Set<string>([
-    'ECONNRESET',
-    'ETIMEDOUT',
-    'ECONNREFUSED',
-    'EAI_AGAIN',
-    'ENOTFOUND',
-    // undici / fetch (Node) internal error codes
-    'UND_ERR_CONNECT_TIMEOUT',
-    'UND_ERR_HEADERS_TIMEOUT',
-    'UND_ERR_BODY_TIMEOUT',
-    'UND_ERR_SOCKET',
-  ]);
-
-  const isRetryableNetworkError = (
-    error: unknown,
-    options: { timedOut: boolean },
-  ): boolean => {
-    if (!error) {
-      return false;
-    }
-
-    // Retry on our own connection-timeout aborts (may surface as AbortError).
-    if (options.timedOut && isAbortError(error)) {
-      return true;
-    }
-
-    const directCode = tryGetErrorCode(error);
-    if (directCode && retryableCodes.has(directCode)) {
-      return true;
-    }
-
-    if (hasCause(error)) {
-      const causeCode = tryGetErrorCode(error.cause);
-      if (causeCode && retryableCodes.has(causeCode)) {
-        return true;
-      }
-    }
-
-    if (error instanceof Error) {
-      const message = error.message.toLowerCase();
-      if (
-        message.includes('fetch failed') ||
-        message.includes('network error') ||
-        message.includes('socket hang up')
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
   while (attempt <= maxRetries) {
     // Create timeout controller for connection timeout
     const timeoutController = new AbortController();
@@ -1449,8 +1479,6 @@ export async function fetchWithRetryUsingFetch(
 
       // Retryable connection/network errors.
       if (
-        (error instanceof Error &&
-          error.message.includes('Connection timeout')) ||
         isRetryableNetworkError(error, {
           timedOut: timeoutController.signal.aborted,
         })


### PR DESCRIPTION
## Summary

Fixes handling of transient chat stream socket closures such as:

`SocketError: other side closed at TLSSocket.onHttpSocketEnd (...undici/lib/dispatcher/client-h1.js)`

The error can happen after the initial `fetch()` succeeds, while the streaming response body is being read. Existing fetch retry logic does not cover that phase.

## Changes

- Centralize retryable network error detection in `utils`.
- Detect retryable network error codes and messages through nested `cause` chains.
- Treat `other side closed` / `UND_ERR_SOCKET` as retryable transient network failures.
- Retry full chat streams only when no response parts have been emitted yet.
- Reuse the centralized retryable network error helper in Google Code Assist.

## Why

When GitHub Copilot or another provider closes an SSE/streaming connection before the first response part, VS Code currently receives a hard failure even though retrying the whole request is safe enough: no partial response has been surfaced to the user yet.

The retry is intentionally limited to `partCount === 0` to avoid duplicated output or replaying partially emitted streams.

## Validation

- `npm run compile` passes.
