### PR TITLE
Fix Codex Responses stream read recovery

### DIFF
--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -337,6 +337,14 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
     ensureCodexImageGenerationTool(baseBody);
   }
 
+  protected override getMinimumStreamReadRetries(): number {
+    return 1;
+  }
+
+  protected override shouldFallbackToNonStreamingAfterStreamReadError(): boolean {
+    return true;
+  }
+
   protected override createClient(
     logger: ProviderHttpLogger | undefined,
     stream: boolean,

--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -338,7 +338,7 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
   }
 
   protected override getMinimumStreamReadRetries(): number {
-    return 1;
+    return 2;
   }
 
   protected override shouldFallbackToNonStreamingAfterStreamReadError(): boolean {

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -29,6 +29,10 @@ import {
   resolveOpenAISdkTimeoutMs,
   sanitizeMessagesForModelSwitchDetailed,
   withIdleTimeout,
+  calculateBackoffDelay,
+  delay,
+  describeNetworkError,
+  isAbortLikeError,
 } from '../../utils';
 import {
   buildBaseUrl,
@@ -79,6 +83,9 @@ const VOLC_CONTEXT_CACHE_MAX_TTL_SECONDS = 604_800;
 const PREVIOUS_RESPONSE_ID_ERROR_CODES = new Set<string>([
   'invalid_previous_response_id',
   'previous_response_not_found',
+]);
+const STREAM_READ_RETRYABLE_ERROR_CODES = new Set<string>([
+  'stream_read_error',
 ]);
 const WEBSOCKET_CONNECTION_LIMIT_ERROR_CODE =
   'websocket_connection_limit_reached';
@@ -1145,6 +1152,49 @@ export class OpenAIResponsesProvider implements ApiProvider {
     return this.isPreviousResponseIdTextMatch(details.message);
   }
 
+  private isRetryableStreamReadError(error: unknown): boolean {
+    if (isAbortLikeError(error)) {
+      return false;
+    }
+
+    const details = this.extractResponseError(error);
+    if (details.status !== undefined && details.status < 500) {
+      return false;
+    }
+
+    if (
+      details.code &&
+      STREAM_READ_RETRYABLE_ERROR_CODES.has(details.code)
+    ) {
+      return true;
+    }
+
+    const message = details.message.toLowerCase();
+    return (
+      message.includes('stream_read_error') ||
+      message.includes('stream read error') ||
+      message.includes('terminated') ||
+      message.includes('socket hang up') ||
+      message.includes('connection reset') ||
+      message.includes('econnreset')
+    );
+  }
+
+  private shouldRetryStreamReadError(
+    error: unknown,
+    emittedPartCount: number,
+    attempt: number,
+    maxRetries: number,
+    token: CancellationToken,
+  ): boolean {
+    return (
+      !token.isCancellationRequested &&
+      emittedPartCount === 0 &&
+      attempt <= maxRetries &&
+      this.isRetryableStreamReadError(error)
+    );
+  }
+
   private describeTransportError(error: unknown): string {
     const parts: string[] = [];
 
@@ -1421,6 +1471,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
     let shouldUseContinuation = context.continuation !== undefined;
     let attempt = 0;
+    const retryConfig = resolveChatNetwork(this.config).retry;
 
     while (true) {
       attempt += 1;
@@ -1492,6 +1543,28 @@ export class OpenAIResponsesProvider implements ApiProvider {
         }
         return;
       } catch (error) {
+        if (
+          this.shouldRetryStreamReadError(
+            error,
+            emittedPartCount,
+            attempt,
+            retryConfig.maxRetries,
+            context.token,
+          )
+        ) {
+          const delayMs = calculateBackoffDelay(attempt - 1, retryConfig);
+          context.logger.retry(
+            attempt,
+            retryConfig.maxRetries,
+            0,
+            delayMs,
+            undefined,
+            `OpenAI Responses stream read failed before output: ${describeNetworkError(error)}`,
+          );
+          await delay(delayMs, context.abortController.signal);
+          continue;
+        }
+
         if (
           !shouldUseContinuation ||
           emittedPartCount > 0 ||

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -1173,10 +1173,19 @@ export class OpenAIResponsesProvider implements ApiProvider {
     return (
       message.includes('stream_read_error') ||
       message.includes('stream read error') ||
+      this.isRetryableProviderProcessingError(message) ||
       message.includes('terminated') ||
       message.includes('socket hang up') ||
       message.includes('connection reset') ||
       message.includes('econnreset')
+    );
+  }
+
+  private isRetryableProviderProcessingError(message: string): boolean {
+    return (
+      message.includes('an error occurred while processing your request') &&
+      (message.includes('retry your request') ||
+        message.includes('try again'))
     );
   }
 

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -1195,6 +1195,16 @@ export class OpenAIResponsesProvider implements ApiProvider {
     );
   }
 
+  protected getMinimumStreamReadRetries(): number {
+    return 0;
+  }
+
+  protected shouldFallbackToNonStreamingAfterStreamReadError(
+    _error: unknown,
+  ): boolean {
+    return false;
+  }
+
   private describeTransportError(error: unknown): string {
     const parts: string[] = [];
 
@@ -1472,6 +1482,11 @@ export class OpenAIResponsesProvider implements ApiProvider {
     let shouldUseContinuation = context.continuation !== undefined;
     let attempt = 0;
     const retryConfig = resolveChatNetwork(this.config).retry;
+    const streamReadMaxRetries = Math.max(
+      retryConfig.maxRetries,
+      this.getMinimumStreamReadRetries(),
+    );
+    let didFallbackToNonStreaming = false;
 
     while (true) {
       attempt += 1;
@@ -1548,14 +1563,14 @@ export class OpenAIResponsesProvider implements ApiProvider {
             error,
             emittedPartCount,
             attempt,
-            retryConfig.maxRetries,
+            streamReadMaxRetries,
             context.token,
           )
         ) {
           const delayMs = calculateBackoffDelay(attempt - 1, retryConfig);
           context.logger.retry(
             attempt,
-            retryConfig.maxRetries,
+            streamReadMaxRetries,
             0,
             delayMs,
             undefined,
@@ -1563,6 +1578,53 @@ export class OpenAIResponsesProvider implements ApiProvider {
           );
           await delay(delayMs, context.abortController.signal);
           continue;
+        }
+
+        if (
+          context.streamEnabled &&
+          emittedPartCount === 0 &&
+          !didFallbackToNonStreaming &&
+          !context.token.isCancellationRequested &&
+          this.isRetryableStreamReadError(error) &&
+          this.shouldFallbackToNonStreamingAfterStreamReadError(error)
+        ) {
+          didFallbackToNonStreaming = true;
+          context.logger.verbose(
+            `OpenAI Responses stream read failed before output after ${attempt} attempt(s); retrying once with non-streaming HTTP.`,
+          );
+          const fallbackClient = this.createClient(
+            context.logger,
+            false,
+            context.credential,
+            context.abortController.signal,
+          );
+          const fallbackRequestBody = this.buildRequestBodyForAttempt(
+            context.baseBody,
+            context.fullInput,
+            context.continuation,
+            shouldUseContinuation,
+            false,
+          );
+          const data = await fallbackClient.responses.create(
+            { ...fallbackRequestBody, stream: false },
+            {
+              headers: context.headers,
+              signal: context.abortController.signal,
+            },
+          );
+          for await (const part of this.parseMessage(
+            data,
+            context.sessionId,
+            context.performanceTrace,
+            context.logger,
+            context.expectedIdentity,
+            context.includeResponseIdInMarker,
+            'http',
+            context.imageGenerationOutputMimeType,
+          )) {
+            yield part;
+          }
+          return;
         }
 
         if (

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -86,6 +86,7 @@ const PREVIOUS_RESPONSE_ID_ERROR_CODES = new Set<string>([
 ]);
 const STREAM_READ_RETRYABLE_ERROR_CODES = new Set<string>([
   'stream_read_error',
+  'internal_server_error',
 ]);
 const WEBSOCKET_CONNECTION_LIMIT_ERROR_CODE =
   'websocket_connection_limit_reached';
@@ -1169,10 +1170,21 @@ export class OpenAIResponsesProvider implements ApiProvider {
       return true;
     }
 
+    if (details.type === 'internal_server_error') {
+      return true;
+    }
+
     const message = details.message.toLowerCase();
+    const isInternalStreamError =
+      (message.includes('internal_server_error') ||
+        message.includes('internal_error')) &&
+      (message.includes('stream error') ||
+        message.includes('stream id') ||
+        message.includes('received from peer'));
     return (
       message.includes('stream_read_error') ||
       message.includes('stream read error') ||
+      isInternalStreamError ||
       this.isRetryableProviderProcessingError(message) ||
       message.includes('terminated') ||
       message.includes('socket hang up') ||

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -86,10 +86,6 @@ const PREVIOUS_RESPONSE_ID_ERROR_CODES = new Set<string>([
 ]);
 const STREAM_READ_RETRYABLE_ERROR_CODES = new Set<string>([
   'stream_read_error',
-  'internal_server_error',
-]);
-const STREAM_READ_RETRYABLE_ERROR_TYPES = new Set<string>([
-  'internal_server_error',
 ]);
 const WEBSOCKET_CONNECTION_LIMIT_ERROR_CODE =
   'websocket_connection_limit_reached';
@@ -1173,20 +1169,10 @@ export class OpenAIResponsesProvider implements ApiProvider {
       return true;
     }
 
-    if (
-      details.type &&
-      STREAM_READ_RETRYABLE_ERROR_TYPES.has(details.type)
-    ) {
-      return true;
-    }
-
     const message = details.message.toLowerCase();
     return (
       message.includes('stream_read_error') ||
       message.includes('stream read error') ||
-      message.includes('internal_server_error') ||
-      message.includes('internal_error') ||
-      message.includes('received from peer') ||
       this.isRetryableProviderProcessingError(message) ||
       message.includes('terminated') ||
       message.includes('socket hang up') ||

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -86,6 +86,10 @@ const PREVIOUS_RESPONSE_ID_ERROR_CODES = new Set<string>([
 ]);
 const STREAM_READ_RETRYABLE_ERROR_CODES = new Set<string>([
   'stream_read_error',
+  'internal_server_error',
+]);
+const STREAM_READ_RETRYABLE_ERROR_TYPES = new Set<string>([
+  'internal_server_error',
 ]);
 const WEBSOCKET_CONNECTION_LIMIT_ERROR_CODE =
   'websocket_connection_limit_reached';
@@ -1169,10 +1173,20 @@ export class OpenAIResponsesProvider implements ApiProvider {
       return true;
     }
 
+    if (
+      details.type &&
+      STREAM_READ_RETRYABLE_ERROR_TYPES.has(details.type)
+    ) {
+      return true;
+    }
+
     const message = details.message.toLowerCase();
     return (
       message.includes('stream_read_error') ||
       message.includes('stream read error') ||
+      message.includes('internal_server_error') ||
+      message.includes('internal_error') ||
+      message.includes('received from peer') ||
       this.isRetryableProviderProcessingError(message) ||
       message.includes('terminated') ||
       message.includes('socket hang up') ||

--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -120,6 +120,18 @@ type ExtractedResponseError = {
   param?: string;
 };
 
+type StreamRetryReplayChannel = {
+  emitted: string;
+  replayTargetLength: number;
+  replayOffset: number;
+};
+
+type StreamReadRetryState = {
+  text: StreamRetryReplayChannel;
+  thinking: StreamRetryReplayChannel;
+  hasNonReplayableOutput: boolean;
+};
+
 type OpenAIResponsesRequestContext = {
   sessionId: string;
   streamEnabled: boolean;
@@ -1203,14 +1215,14 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
   private shouldRetryStreamReadError(
     error: unknown,
-    emittedPartCount: number,
+    retryState: StreamReadRetryState,
     attempt: number,
     maxRetries: number,
     token: CancellationToken,
   ): boolean {
     return (
       !token.isCancellationRequested &&
-      emittedPartCount === 0 &&
+      this.canReplayStreamReadOutput(retryState) &&
       attempt <= maxRetries &&
       this.isRetryableStreamReadError(error)
     );
@@ -1224,6 +1236,129 @@ export class OpenAIResponsesProvider implements ApiProvider {
     _error: unknown,
   ): boolean {
     return false;
+  }
+
+  private createStreamReadRetryState(): StreamReadRetryState {
+    const createChannel = (): StreamRetryReplayChannel => ({
+      emitted: '',
+      replayTargetLength: 0,
+      replayOffset: 0,
+    });
+
+    return {
+      text: createChannel(),
+      thinking: createChannel(),
+      hasNonReplayableOutput: false,
+    };
+  }
+
+  private prepareStreamReadRetryAttempt(state: StreamReadRetryState): void {
+    state.text.replayTargetLength = state.text.emitted.length;
+    state.text.replayOffset = 0;
+    state.thinking.replayTargetLength = state.thinking.emitted.length;
+    state.thinking.replayOffset = 0;
+  }
+
+  private hasStreamReadOutput(state: StreamReadRetryState): boolean {
+    return (
+      state.hasNonReplayableOutput ||
+      state.text.emitted.length > 0 ||
+      state.thinking.emitted.length > 0
+    );
+  }
+
+  private canReplayStreamReadOutput(state: StreamReadRetryState): boolean {
+    return !state.hasNonReplayableOutput;
+  }
+
+  private describeStreamReadRetry(
+    error: unknown,
+    state: StreamReadRetryState,
+  ): string {
+    const timing = this.hasStreamReadOutput(state)
+      ? 'after replayable text/thinking output'
+      : 'before output';
+    return `OpenAI Responses stream read failed ${timing}: ${describeNetworkError(error)}`;
+  }
+
+  private countCommonPrefixLength(left: string, right: string): number {
+    const limit = Math.min(left.length, right.length);
+    let index = 0;
+    while (index < limit && left.charCodeAt(index) === right.charCodeAt(index)) {
+      index++;
+    }
+    return index;
+  }
+
+  private filterReplayPrefix(
+    value: string,
+    channel: StreamRetryReplayChannel,
+  ): string | undefined {
+    const remainingReplayPrefix = channel.emitted.slice(
+      channel.replayOffset,
+      channel.replayTargetLength,
+    );
+    if (remainingReplayPrefix.length === 0) {
+      channel.emitted += value;
+      return value;
+    }
+
+    const skipLength = this.countCommonPrefixLength(
+      value,
+      remainingReplayPrefix,
+    );
+    channel.replayOffset += skipLength;
+
+    const suffix = value.slice(skipLength);
+    if (!suffix) {
+      return undefined;
+    }
+
+    if (channel.replayOffset < channel.replayTargetLength) {
+      channel.replayOffset = channel.replayTargetLength;
+    }
+    channel.emitted += suffix;
+    return suffix;
+  }
+
+  private normalizeThinkingPartValue(value: string | string[]): string {
+    return Array.isArray(value) ? value.join('') : value;
+  }
+
+  private filterStreamReadRetryPart(
+    part: vscode.LanguageModelResponsePart2,
+    state: StreamReadRetryState,
+  ): vscode.LanguageModelResponsePart2 | undefined {
+    if (part instanceof vscode.LanguageModelTextPart) {
+      const value = part.value;
+      const suffix = this.filterReplayPrefix(value, state.text);
+      return suffix === undefined
+        ? undefined
+        : suffix === value
+          ? part
+          : new vscode.LanguageModelTextPart(suffix);
+    }
+
+    if (part instanceof vscode.LanguageModelThinkingPart) {
+      const value = this.normalizeThinkingPartValue(part.value);
+      if (!value) {
+        state.hasNonReplayableOutput = true;
+        return part;
+      }
+      const suffix = this.filterReplayPrefix(value, state.thinking);
+      return suffix === undefined
+        ? undefined
+        : suffix === value
+          ? part
+          : new vscode.LanguageModelThinkingPart(
+              suffix,
+              part.id,
+              part.metadata,
+            );
+    }
+
+    state.hasNonReplayableOutput = true;
+    return part;
   }
 
   private describeTransportError(error: unknown): string {
@@ -1508,9 +1643,11 @@ export class OpenAIResponsesProvider implements ApiProvider {
       this.getMinimumStreamReadRetries(),
     );
     let didFallbackToNonStreaming = false;
+    const retryState = this.createStreamReadRetryState();
 
     while (true) {
       attempt += 1;
+      this.prepareStreamReadRetryAttempt(retryState);
       context.performanceTrace.ttf = Date.now() - context.performanceTrace.tts;
       const requestBody = this.buildRequestBodyForAttempt(
         context.baseBody,
@@ -1522,7 +1659,6 @@ export class OpenAIResponsesProvider implements ApiProvider {
       context.logger.verbose(
         `OpenAI Responses HTTP attempt ${attempt} | transport=${context.streamEnabled ? 'sse' : 'http'} | session=${context.sessionId} | continuation=${shouldUseContinuation ? 'previous_response_id' : 'full_input'} | inputItems=${this.countInputItems(requestBody.input)} | store=${requestBody.store === false ? 'false' : 'default/true'}`,
       );
-      let emittedPartCount = 0;
 
       try {
         if (context.streamEnabled) {
@@ -1552,8 +1688,13 @@ export class OpenAIResponsesProvider implements ApiProvider {
             context.streamEnabled ? 'sse' : 'http',
             context.imageGenerationOutputMimeType,
           )) {
-            emittedPartCount++;
-            yield part;
+            const filteredPart = this.filterStreamReadRetryPart(
+              part,
+              retryState,
+            );
+            if (filteredPart) {
+              yield filteredPart;
+            }
           }
         } else {
           const data = await client.responses.create(
@@ -1573,8 +1714,13 @@ export class OpenAIResponsesProvider implements ApiProvider {
             'http',
             context.imageGenerationOutputMimeType,
           )) {
-            emittedPartCount++;
-            yield part;
+            const filteredPart = this.filterStreamReadRetryPart(
+              part,
+              retryState,
+            );
+            if (filteredPart) {
+              yield filteredPart;
+            }
           }
         }
         return;
@@ -1582,7 +1728,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
         if (
           this.shouldRetryStreamReadError(
             error,
-            emittedPartCount,
+            retryState,
             attempt,
             streamReadMaxRetries,
             context.token,
@@ -1595,7 +1741,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
             0,
             delayMs,
             undefined,
-            `OpenAI Responses stream read failed before output: ${describeNetworkError(error)}`,
+            this.describeStreamReadRetry(error, retryState),
           );
           await delay(delayMs, context.abortController.signal);
           continue;
@@ -1603,15 +1749,16 @@ export class OpenAIResponsesProvider implements ApiProvider {
 
         if (
           context.streamEnabled &&
-          emittedPartCount === 0 &&
           !didFallbackToNonStreaming &&
           !context.token.isCancellationRequested &&
+          this.canReplayStreamReadOutput(retryState) &&
           this.isRetryableStreamReadError(error) &&
           this.shouldFallbackToNonStreamingAfterStreamReadError(error)
         ) {
           didFallbackToNonStreaming = true;
+          this.prepareStreamReadRetryAttempt(retryState);
           context.logger.verbose(
-            `OpenAI Responses stream read failed before output after ${attempt} attempt(s); retrying once with non-streaming HTTP.`,
+            `OpenAI Responses stream read failed before completion after ${attempt} attempt(s); retrying once with non-streaming HTTP.`,
           );
           const fallbackClient = this.createClient(
             context.logger,
@@ -1643,14 +1790,20 @@ export class OpenAIResponsesProvider implements ApiProvider {
             'http',
             context.imageGenerationOutputMimeType,
           )) {
-            yield part;
+            const filteredPart = this.filterStreamReadRetryPart(
+              part,
+              retryState,
+            );
+            if (filteredPart) {
+              yield filteredPart;
+            }
           }
           return;
         }
 
         if (
           !shouldUseContinuation ||
-          emittedPartCount > 0 ||
+          this.hasStreamReadOutput(retryState) ||
           !this.shouldRetryWithoutPreviousResponseId(error)
         ) {
           throw error;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,6 @@ import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 import { CONFIG_NAMESPACE } from './config-store';
 
 const CHANNEL_NAME = 'Unify Chat Provider';
-const MAX_LOG_PAYLOAD_CHARS = 12000;
 
 let channel: vscode.LogOutputChannel | undefined;
 let nextRequestId = 1;
@@ -54,29 +53,6 @@ function maskValue(value?: string): string {
     return '*'.repeat(value.length);
   }
   return `${value.slice(0, 4)}…${value.slice(-4)}`;
-}
-
-function isSensitiveLogKey(key: string): boolean {
-  const lower = key.toLowerCase();
-  return (
-    lower === 'authorization' ||
-    lower === 'x-api-key' ||
-    lower === 'token' ||
-    lower.endsWith('_token') ||
-    lower.endsWith('-token') ||
-    lower.includes('api_key') ||
-    lower.includes('apikey') ||
-    lower.includes('password') ||
-    lower.includes('secret')
-  );
-}
-
-function truncateLogPayload(text: string): string {
-  if (text.length <= MAX_LOG_PAYLOAD_CHARS) {
-    return text;
-  }
-  const omitted = text.length - MAX_LOG_PAYLOAD_CHARS;
-  return `${text.slice(0, MAX_LOG_PAYLOAD_CHARS)}\n... [truncated ${omitted} chars]`;
 }
 
 function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
@@ -145,10 +121,6 @@ function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if (isSensitiveLogKey(key)) {
-      out[key] = typeof child === 'string' ? maskValue(child) : '[Redacted]';
-      continue;
-    }
     out[key] = sanitizeForLog(child, seen);
   }
   return out;
@@ -157,7 +129,7 @@ function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
 function stringifyForLog(value: unknown): string {
   try {
     const json = JSON.stringify(sanitizeForLog(value, new WeakSet()), null, 2);
-    return truncateLogPayload(json ?? 'undefined');
+    return json ?? 'undefined';
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return `<<Failed to stringify for log: ${message}>>`;
@@ -298,8 +270,10 @@ export class RequestLogger implements ProviderHttpLogger {
         )}`,
       );
       this.ch.info(
-        `[${this.requestId}] Provider Request Body:\n${stringifyForLog(
+        `[${this.requestId}] Provider Request Body:\n${JSON.stringify(
           details.body ?? null,
+          null,
+          2,
         )}`,
       );
       this.providerContext.logged = true;
@@ -520,7 +494,11 @@ export class RequestLogger implements ProviderHttpLogger {
       )}`,
     );
     this.ch.error(
-      `[${this.requestId}] Provider Request Body:\n${stringifyForLog(ctx.body)}`,
+      `[${this.requestId}] Provider Request Body:\n${JSON.stringify(
+        ctx.body,
+        null,
+        2,
+      )}`,
     );
     ctx.logged = true;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,6 +7,7 @@ import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 import { CONFIG_NAMESPACE } from './config-store';
 
 const CHANNEL_NAME = 'Unify Chat Provider';
+const MAX_LOG_PAYLOAD_CHARS = 12000;
 
 let channel: vscode.LogOutputChannel | undefined;
 let nextRequestId = 1;
@@ -53,6 +54,29 @@ function maskValue(value?: string): string {
     return '*'.repeat(value.length);
   }
   return `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function isSensitiveLogKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return (
+    lower === 'authorization' ||
+    lower === 'x-api-key' ||
+    lower === 'token' ||
+    lower.endsWith('_token') ||
+    lower.endsWith('-token') ||
+    lower.includes('api_key') ||
+    lower.includes('apikey') ||
+    lower.includes('password') ||
+    lower.includes('secret')
+  );
+}
+
+function truncateLogPayload(text: string): string {
+  if (text.length <= MAX_LOG_PAYLOAD_CHARS) {
+    return text;
+  }
+  const omitted = text.length - MAX_LOG_PAYLOAD_CHARS;
+  return `${text.slice(0, MAX_LOG_PAYLOAD_CHARS)}\n... [truncated ${omitted} chars]`;
 }
 
 function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
@@ -121,6 +145,10 @@ function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (isSensitiveLogKey(key)) {
+      out[key] = typeof child === 'string' ? maskValue(child) : '[Redacted]';
+      continue;
+    }
     out[key] = sanitizeForLog(child, seen);
   }
   return out;
@@ -129,7 +157,7 @@ function sanitizeForLog(value: unknown, seen: WeakSet<object>): unknown {
 function stringifyForLog(value: unknown): string {
   try {
     const json = JSON.stringify(sanitizeForLog(value, new WeakSet()), null, 2);
-    return json ?? 'undefined';
+    return truncateLogPayload(json ?? 'undefined');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return `<<Failed to stringify for log: ${message}>>`;
@@ -270,10 +298,8 @@ export class RequestLogger implements ProviderHttpLogger {
         )}`,
       );
       this.ch.info(
-        `[${this.requestId}] Provider Request Body:\n${JSON.stringify(
+        `[${this.requestId}] Provider Request Body:\n${stringifyForLog(
           details.body ?? null,
-          null,
-          2,
         )}`,
       );
       this.providerContext.logged = true;
@@ -494,11 +520,7 @@ export class RequestLogger implements ProviderHttpLogger {
       )}`,
     );
     this.ch.error(
-      `[${this.requestId}] Provider Request Body:\n${JSON.stringify(
-        ctx.body,
-        null,
-        2,
-      )}`,
+      `[${this.requestId}] Provider Request Body:\n${stringifyForLog(ctx.body)}`,
     );
     ctx.logged = true;
   }


### PR DESCRIPTION
This PR improves OpenAI Codex Responses handling when SSE streaming fails before any visible output is emitted.

Changes:

- Adds a provider hook for minimum stream-read retry attempts.
- Enables Codex to retry at least once on pre-output stream_read_error, even when normal retry settings are disabled or too low.
- Adds a one-time non-streaming HTTP fallback for Codex after stream-read recovery is exhausted.
- Keeps the fallback scoped to Codex so other OpenAI Responses providers keep their existing behavior.

Verification:

- Ran npm run compile successfully.