### PR TITLE
fix: handle missing OpenAI response output

### DIFF
--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -1922,7 +1922,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
     completedOutputItems: ReadonlyMap<number, ResponseOutputItem>,
     logger: RequestLogger,
   ): ResponseOutputItem[] {
-    const responseOutput = response.output.slice();
+    const responseOutput = Array.isArray(response.output) ? response.output.slice() : [];
     if (
       responseOutput.length === 0 &&
       addedOutputItems.size === 0 &&


### PR DESCRIPTION
## Summary
- Guard `response.output` before calling `.slice()` in the Responses stream completion path.
- Falls back to the already tracked stream output item state when `response.completed` omits `output`.

Closes #198.

## Test plan
- `npm run compile`