### PR TITLE
Move commit generator to SCM input box

### DIFF
--- a/package.json
+++ b/package.json
@@ -1540,7 +1540,7 @@
       }
     },
     "menus": {
-      "scm/title": [
+      "scm/inputBox": [
         {
           "command": "unifyChatProvider.commitMessageGeneration.generate",
           "group": "navigation@-4",


### PR DESCRIPTION
Moves the commit message generation action into VS Code's native SCM input box toolbar.

**Screenshot**:
<img width="606" height="376" alt="file" src="https://github.com/user-attachments/assets/c370e4fb-6a90-466d-ab8e-dee60b821009" />

