### PR TITLE
fix(copilot): optimize rate limits by adding session headers and context cache override

### DIFF
--- a/src/client/github-copilot/client.ts
+++ b/src/client/github-copilot/client.ts
@@ -559,6 +559,7 @@ function applyCopilotHeaders(options: {
   headers: Record<string, string | null>;
   credential?: AuthTokenInfo;
   messages?: readonly LanguageModelChatRequestMessage[];
+  sessionId?: string;
 }): void {
   const headers = options.headers;
 
@@ -582,6 +583,11 @@ function applyCopilotHeaders(options: {
   headers['User-Agent'] = buildOpencodeUserAgent();
   headers['Openai-Intent'] = 'conversation-edits';
   headers['X-GitHub-Api-Version'] = COPILOT_API_VERSION;
+  headers['Copilot-Integration-Id'] = 'vscode-chat';
+
+  if (options.sessionId) {
+    headers['vscode-sessionid'] = options.sessionId;
+  }
 
   if (options.messages) {
     headers['x-initiator'] = inferInitiator(options.messages);
@@ -635,7 +641,7 @@ class GitHubCopilotResponsesProvider extends OpenAIResponsesProvider {
       modelConfig,
       messages,
     );
-    applyCopilotHeaders({ headers, credential, messages });
+    applyCopilotHeaders({ headers, credential, messages, sessionId });
     return headers;
   }
 }
@@ -682,8 +688,15 @@ export class GitHubCopilotProvider implements ApiProvider {
     const extraBody = config.extraBody ?? {};
     const hasStore = Object.prototype.hasOwnProperty.call(extraBody, 'store');
     const configWithDefaults: ProviderConfig = hasStore
-      ? config
-      : { ...config, extraBody: { ...extraBody, store: false } };
+      ? {
+          ...config,
+          contextCache: config.contextCache ?? { type: 'allow-paid' },
+        }
+      : {
+          ...config,
+          contextCache: config.contextCache ?? { type: 'allow-paid' },
+          extraBody: { ...extraBody, store: false },
+        };
     this.providerConfig = configWithDefaults;
 
     this.chatProvider = new GitHubCopilotChatCompletionProvider(


### PR DESCRIPTION
Port optimizations from CLIProxyAPI to reduce aggressive token exhaustion by GitHub Copilot backend:

1. **Context Cache Override**: Automatically set `contextCache: { type: 'allow-paid' }` for GitHub Copilot. Since Copilot operates on flat billing, we can freely utilize prompt caching (like Anthropic's `cache_control`) which drastically reduces prompt tokens.
2. **Session Identification**: Inject `vscode-sessionid` and `Copilot-Integration-Id` headers. Upstream Copilot/Codex handles token context and rate limits better when identifying continuous sessions instead of treating every interaction as a cold start.