### PR TITLE
fix(opencode): add opencode.ai to OpenAIUseReasoningContent supportedProviders

### DIFF
--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -707,6 +707,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
       'api.z.ai',
       'api.moonshot.cn',
       'api.moonshot.ai',
+      'opencode.ai',
       'api.kimi.com',
       'dashscope-intl.aliyuncs.com',
       'dashscope-intl.aliyuncs.com',


### PR DESCRIPTION
## Description

Adds `opencode.ai` to the `supportedProviders` list of `FeatureId.OpenAIUseReasoningContent` in `src/client/definitions.ts`.

## Problem

When using **OpenCode Zen (OpenAI Chat Completion)** or **OpenCode Go (OpenAI Chat Completion)** with a thinking-enabled model (e.g. `deepseek-v4-flash-free`), the `reasoning_content` returned by the API is not preserved and passed back on subsequent requests.

- `OpenAIUseThinkingParam` works correctly because it has a `customChecker` matching model IDs containing `deepseek-v4`
- `OpenAIUseReasoningContent` **only** checks `supportedProviders` against `provider.baseUrl`. Since `opencode.ai` was missing from the list, `isFeatureSupported()` returns `false`, `reasoningType` defaults to `"none"`, and the `LanguageModelThinkingPart` is silently dropped during message conversion

## Impact

The missing `reasoning_content` degrades OpenCode Go's upstream contextual caching. OpenCode Go uses the full conversation state (including `reasoning_content`) for cache key computation. Without it, each turn appears as a new context:

- Cache misses on multi-turn interactions
- Higher latency and token consumption
- Poorer experience for paid OpenCode Go subscribers

## Fix

One-line change: add `"opencode.ai"` to `OpenAIUseReasoningContent.supportedProviders`.

## Related

Closes #220