### PR TITLE
fix(anthropic): backfill missing tool_result blocks for restored tool_use

### DIFF
--- a/src/client/anthropic/client.ts
+++ b/src/client/anthropic/client.ts
@@ -11,7 +11,9 @@ import type {
   BetaTextBlockParam,
   BetaThinkingBlockParam,
   BetaToolChoice,
+  BetaToolResultBlockParam,
   BetaToolUnion,
+  BetaToolUseBlock,
   BetaUsage,
   MessageCreateParamsStreaming,
   BetaTool,
@@ -405,12 +407,94 @@ export class AnthropicProvider implements ApiProvider {
 
     // add a cache breakpoint at the end.
     this.applyCacheControl(system, outMessages);
+    // Workaround: Anthropic requires every assistant tool_use to be followed by
+    // a user tool_result. VSCode drops explicit ToolCallPart/ToolResultPart
+    // during the tool invocation round and only keeps the stateful marker, so
+    // sanitizeMessagesForModelSwitch can discard the user tool_result while
+    // still restoring the assistant tool_use from the marker raw data. Backfill
+    // any missing tool_result with an empty block to keep the API valid.
+    const backfilledMessages = this.backfillMissingToolResults(outMessages);
 
     return {
-      messages: this.ensureAlternatingRoles(outMessages),
+      messages: this.ensureAlternatingRoles(backfilledMessages),
       system: system.length > 0 ? system : undefined,
       historyUserId: firstHistoryUserId,
     };
+  }
+
+  /**
+   * Ensure every assistant tool_use has a corresponding user tool_result.
+   *
+   * Returns a new message array where missing tool_result blocks are either
+   * prepended to the next user message (if one immediately follows) or inserted
+   * as a new user message. The input array is not mutated.
+   */
+  private backfillMissingToolResults(
+    messages: BetaMessageParam[],
+  ): BetaMessageParam[] {
+    const resultIds = new Set<string>();
+    for (const msg of messages) {
+      if (msg.role === 'user' && Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (
+            block.type === 'tool_result' &&
+            (block as BetaToolResultBlockParam).tool_use_id
+          ) {
+            resultIds.add((block as BetaToolResultBlockParam).tool_use_id);
+          }
+        }
+      }
+    }
+
+    const patched: BetaMessageParam[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+
+      if (msg.role !== 'assistant' || !Array.isArray(msg.content)) {
+        patched.push(msg);
+        continue;
+      }
+
+      const missingToolResults: BetaToolResultBlockParam[] = [];
+      for (const block of msg.content) {
+        if (block.type === 'tool_use') {
+          const toolUse = block as BetaToolUseBlock;
+          if (toolUse.id && !resultIds.has(toolUse.id)) {
+            missingToolResults.push({
+              type: 'tool_result',
+              tool_use_id: toolUse.id,
+              content: [],
+            } satisfies BetaToolResultBlockParam);
+          }
+        }
+      }
+
+      patched.push(msg);
+
+      if (missingToolResults.length === 0) {
+        continue;
+      }
+
+      const nextMsg = messages[i + 1];
+      if (
+        nextMsg &&
+        nextMsg.role === 'user' &&
+        Array.isArray(nextMsg.content)
+      ) {
+        patched.push({
+          role: 'user',
+          content: [...missingToolResults, ...nextMsg.content],
+        });
+        i++;
+      } else {
+        patched.push({
+          role: 'user',
+          content: missingToolResults,
+        });
+      }
+    }
+
+    return patched;
   }
 
   private applyCacheControl(


### PR DESCRIPTION
fixes #219 , tested locally, without this, kimi won't work after a while.

## Problem

Anthropic API requires that every assistant message containing `tool_use` blocks must be followed by a user message containing the corresponding `tool_result` blocks.

In VS Code'\''s tool invocation round, explicit `LanguageModelToolCallPart` / `LanguageModelToolResultPart` are dropped from the message content and only the stateful `LanguageModelDataPart` marker is preserved. Later, `sanitizeMessagesForModelSwitch` may discard the user `tool_result` message (for example due to identity mismatch or model switching), but the assistant message is still restored from the marker'\''s raw data, which still contains the original `tool_use` blocks.

This produces a request where an assistant `tool_use` has no matching user `tool_result`, causing Anthropic to return:

```
an assistant message with '\''tool_calls'\'' must be followed by tool messages responding to each '\''tool_call_id'\''. The following tool_call_ids did not have response messages: ...
```

## Fix

In `AnthropicProvider.convertMessages`, after cache control is applied and before `ensureAlternatingRoles`, backfill any missing `tool_result` blocks with empty results. This keeps the API request valid even when the original user tool_result has been sanitized away.

## Notes

- This is a minimal defensive workaround. A more thorough fix would be to make `sanitizeMessagesForModelSwitch` / `propagateSanitizedToolNeighbors` also decode stateful markers when deciding which assistant/user messages to discard.
- The change only affects Anthropic provider output and does not alter message history stored by VS Code.