### PR TITLE
Fix Anthropic trailing assistant prefill requests

### DIFF
--- a/src/client/anthropic/client.ts
+++ b/src/client/anthropic/client.ts
@@ -470,7 +470,7 @@ export class AnthropicProvider implements ApiProvider {
   }
 
   /**
-   * Ensure messages alternate between user and assistant roles
+   * Normalize messages to alternate roles and end with a user message.
    */
   private ensureAlternatingRoles(
     messages: BetaMessageParam[],
@@ -528,6 +528,13 @@ export class AnthropicProvider implements ApiProvider {
       throw new Error(
         'The first message must be from the user role for Anthropic API',
       );
+    }
+
+    if (result.at(-1)?.role === 'assistant') {
+      result.push({
+        role: 'user',
+        content: [{ type: 'text', text: 'Continue.' }],
+      });
     }
 
     return result;


### PR DESCRIPTION
## Summary
- Preserve trailing assistant messages during Anthropic role normalization.
- Append a minimal user continuation when the normalized conversation ends with an assistant message.
- Prevent models that reject assistant prefill from receiving an invalid request without discarding the latest assistant context.

## Root cause
VS Code/Copilot Chat can issue internal continuation or cache keep-alive requests whose message history ends with an assistant message. The VS Code language model API does not guarantee a trailing user message, while Claude Opus 4.8 rejects assistant prefill with: `This model does not support assistant message prefill. The conversation must end with a user message.`

The previous revision removed trailing assistant messages. This revision instead retains that context and appends a minimal `Continue.` user message, preserving the conversation and prompt-cache prefix while satisfying Anthropic's request constraint.

## Validation
- `get_errors` on `src/client/anthropic/client.ts`: no errors.
- `git diff --check`: passed.
- `npm run compile`: still fails on existing unrelated OpenAI files:
  - `src/client/openai/responses-client.ts` around `additional_tools` narrowing
  - `src/client/openai/responses-websocket-transport.ts` around `platformSocket`