### PR TITLE
fix(openai-responses): tolerate missing input token details

### DIFF
--- a/src/client/openai/responses-client.ts
+++ b/src/client/openai/responses-client.ts
@@ -2755,7 +2755,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
       markerData.usage = createCopilotUsage(
         message.usage.input_tokens,
         message.usage.output_tokens,
-        message.usage.input_tokens_details.cached_tokens,
+        OpenAIResponsesProvider.resolveCachedInputTokens(message.usage),
       );
     }
     yield encodeStatefulMarkerPart<OpenAIResponsesMarkerData>(
@@ -3346,7 +3346,7 @@ export class OpenAIResponsesProvider implements ApiProvider {
             markerData.usage = createCopilotUsage(
               response.usage.input_tokens,
               response.usage.output_tokens,
-              response.usage.input_tokens_details.cached_tokens,
+              OpenAIResponsesProvider.resolveCachedInputTokens(response.usage),
             );
           }
           yield encodeStatefulMarkerPart<OpenAIResponsesMarkerData>(
@@ -3426,9 +3426,16 @@ export class OpenAIResponsesProvider implements ApiProvider {
     const normalizedUsage = createCopilotUsage(
       usage.input_tokens,
       usage.output_tokens,
-      usage.input_tokens_details.cached_tokens,
+      OpenAIResponsesProvider.resolveCachedInputTokens(usage),
     );
     sharedProcessUsage(requestTrace, logger, normalizedUsage);
+  }
+
+  private static resolveCachedInputTokens(usage: ResponseUsage): number {
+    // OpenAI-compatible gateways may omit `input_tokens_details` entirely.
+    // Treat the missing details object as zero cached input tokens so the
+    // completion path does not throw on otherwise valid Responses payloads.
+    return usage.input_tokens_details?.cached_tokens ?? 0;
   }
 
   estimateTokenCount(text: string): number {

--- a/test/unit/openai-responses-output.test.ts
+++ b/test/unit/openai-responses-output.test.ts
@@ -191,7 +191,10 @@ function createRefusal(refusal: string): ResponseOutputMessage {
   };
 }
 
-function createResponse(output: ResponseOutputItem[]): Response {
+function createResponse(
+  output: ResponseOutputItem[],
+  responseUsage: ResponseUsage = usage,
+): Response {
   return {
     id: 'resp_test',
     created_at: 1,
@@ -216,7 +219,7 @@ function createResponse(output: ResponseOutputItem[]): Response {
     tools: [],
     top_p: null,
     status: 'completed',
-    usage,
+    usage: responseUsage,
   };
 }
 
@@ -469,5 +472,83 @@ describe('OpenAI Responses output parsing', () => {
     ).rejects.toThrow(
       'OpenAI Responses API completed without output text, refusal, tool calls, or other consumable output.',
     );
+  });
+});
+
+describe('OpenAI Responses usage normalization', () => {
+  // Some OpenAI-compatible gateways omit `usage.input_tokens_details` entirely
+  // while still returning a valid, otherwise consumable response. Cast once
+  // here so the regression tests below can exercise the same shape.
+  const usageWithoutDetails = {
+    input_tokens: 1234,
+    output_tokens: 567,
+    total_tokens: 1801,
+  } as unknown as ResponseUsage;
+
+  function readMarkerCachedTokens(
+    parts: readonly vscode.LanguageModelResponsePart2[],
+  ): number | undefined {
+    const dataPart = parts.find(
+      (part): part is vscode.LanguageModelDataPart =>
+        part instanceof vscode.LanguageModelDataPart,
+    );
+    if (!dataPart) {
+      return undefined;
+    }
+    const decoded = JSON.parse(
+      Buffer.from(dataPart.data).toString('utf8'),
+    ) as { usage?: { prompt_tokens_details?: { cached_tokens?: number } } };
+    return decoded.usage?.prompt_tokens_details?.cached_tokens;
+  }
+
+  it('completes HTTP responses when input_tokens_details is omitted', async () => {
+    const message = createMessage('hi');
+    const requestTrace = createTrace();
+    const parts = await collectParts(
+      provider.parseResponseForTest(
+        createResponse([message], usageWithoutDetails),
+        requestTrace,
+      ),
+    );
+
+    expect(textValues(parts)).toEqual(['hi']);
+    expect(readMarkerCachedTokens(parts)).toBe(0);
+    expect(requestTrace.usage?.prompt_tokens_details.cached_tokens).toBe(0);
+  });
+
+  it('completes streamed responses when input_tokens_details is omitted', async () => {
+    const message = createMessage('hi');
+    const requestTrace = createTrace();
+    const parts = await collectParts(
+      provider.parseStreamForTest(
+        [
+          {
+            type: 'response.output_text.delta',
+            content_index: 0,
+            delta: 'hi',
+            item_id: message.id,
+            logprobs: [],
+            output_index: 0,
+            sequence_number: 1,
+          },
+          {
+            type: 'response.output_item.done',
+            item: message,
+            output_index: 0,
+            sequence_number: 2,
+          },
+          {
+            type: 'response.completed',
+            response: createResponse([message], usageWithoutDetails),
+            sequence_number: 3,
+          },
+        ],
+        requestTrace,
+      ),
+    );
+
+    expect(textValues(parts)).toEqual(['hi']);
+    expect(readMarkerCachedTokens(parts)).toBe(0);
+    expect(requestTrace.usage?.prompt_tokens_details.cached_tokens).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

OpenAI Responses provider tolerates Responses-compatible gateways that omit `usage.input_tokens_details` from their completion payloads. The provider no longer throws `Cannot read properties of undefined (reading 'cached_tokens')` immediately after a response completes.

Fixes #276

## Root cause

The gateway payload is **not fully conformant to the OpenAI Responses schema** — it omits the optional `input_tokens_details` object — but the text and the core usage fields are otherwise fine.

`src/client/openai/responses-client.ts` read `usage.input_tokens_details.cached_tokens` directly in three places:

- HTTP completion (`parseMessage`, marker construction)
- Stream completion (`parseMessageStream`, marker construction)
- Shared `processUsage` post-loop path

When an OpenAI-compatible gateway omits the details object entirely, each access threw and retroactively failed an already-delivered response.

## Before / after

Before:

```ts
markerData.usage = createCopilotUsage(
  message.usage.input_tokens,
  message.usage.output_tokens,
  message.usage.input_tokens_details.cached_tokens, // throws when details are missing
);
```

After:

```ts
markerData.usage = createCopilotUsage(
  message.usage.input_tokens,
  message.usage.output_tokens,
  OpenAIResponsesProvider.resolveCachedInputTokens(message.usage),
);

// ...
private static resolveCachedInputTokens(usage: ResponseUsage): number {
  // OpenAI-compatible gateways may omit `input_tokens_details` entirely.
  // Treat the missing details object as zero cached input tokens so the
  // completion path does not throw on otherwise consumable Responses payloads.
  return usage.input_tokens_details?.cached_tokens ?? 0;
}
```

The chat response now completes normally with `cached_tokens = 0` when `input_tokens_details` is absent. Reported `input_tokens`, `output_tokens`, and `total_tokens` are preserved, the real `cached_tokens` value is still used when it is supplied, and unrelated malformed-response errors are not swallowed.

## Test coverage

Two minimal regression tests in `test/unit/openai-responses-output.test.ts`:

- HTTP path (`parseMessage`) with `input_tokens_details` omitted
- Stream completion path (`parseMessageStream`) with `input_tokens_details` omitted

Both cases assert that the stream does not throw, that the marker `usage` payload reports `cached_tokens = 0`, and that `requestTrace.usage.prompt_tokens_details.cached_tokens` is `0`. The existing `usage` const in the same test file already exercises the happy path with a real `cached_tokens = 2`, so no extra nonzero case is needed.

The new cases would fail on `main` with the original `TypeError: Cannot read properties of undefined (reading 'cached_tokens')`.

## Commands executed

```bash
git clone --depth 50 https://github.com/smallmain/vscode-unify-chat-provider.git
npm install --no-audit --no-fund --prefer-offline
npm run test:unit
npm run verify:chat-lib
npm run l10n:check
npm run compile
```

Results:

| Command | Result |
| --- | --- |
| `npm run test:unit` | 102 test files, 1217 tests passing |
| `npm run verify:chat-lib` | 34 attributed snapshots, 41 strict runtime files, 14 strict host adapters verified |
| `npm run l10n:check` | no missing/extra keys, no new non-literal `t()` calls |
| `npm run compile` | clean (`tsc -p .` + `build:chat-lib-runtime`) |

## Compatibility rationale

- The patch only changes how cached input tokens are derived from `usage.input_tokens_details`. `input_tokens`, `output_tokens`, and `total_tokens` flow through unchanged.
- Official OpenAI Responses payloads include `input_tokens_details`, so the real `cached_tokens` value continues to be used.
- OpenAI-compatible gateways that omit the details object now report `0` cached input tokens instead of crashing an already-completed response.
- Other providers (`chat-completion-client`, `ollama/client`, `google/ai-studio-client`, `anthropic/client`) were intentionally left untouched.

## Files changed

- `src/client/openai/responses-client.ts` — three call sites now go through `OpenAIResponsesProvider.resolveCachedInputTokens(...)`; new `private static` helper added next to `processUsage`.
- `test/unit/openai-responses-output.test.ts` — `createResponse` accepts an optional `ResponseUsage` override; new `OpenAI Responses usage normalization` describe block with two regression cases.

## Security / privacy

No custom endpoint URL, API key, account information, or private request content is included in this PR.
