### PR TITLE
fix: use Responses API for DeepSeek by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This section uses DeepSeek as an example, adding the provider and two models.
    - You can create multiple configs for the same provider with different names, e.g., `DeepSeek-Person`, `DeepSeek-Team`.
 
 3. Choose the API format: `API Format`.
-   - DeepSeek uses the `OpenAI Chat Completion` format, so select that.
+   - DeepSeek uses the `OpenAI Responses` format by default, so select that.
    - To see all supported formats, refer to the [API Format Support Table](#api-format-support-table).
 
 4. Set the base URL: `API Base URL`.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -198,7 +198,7 @@ Zed 编辑器使用自研的 Zeta 系列模型，这里推荐两种方式添加�
    - 同一个供应商可以添加多个不同名称的配置，比如 `DeepSeek-Person`、`DeepSeek-Team`。
 
 3. 填写接口格式：`API 格式`。
-   - DeepSeek 的接口是 `OpenAI Chat Completion` 格式，所以选则该格式。
+   - DeepSeek 默认使用 `OpenAI Responses` 格式，所以选择该格式。
    - 要了解支持的所有格式可查看 [API 格式支持表](#api-格式支持表)。
 
 4. 填写基础 URL：`API 基础 URL`。

--- a/src/well-known/providers.ts
+++ b/src/well-known/providers.ts
@@ -455,7 +455,7 @@ export const WELL_KNOWN_PROVIDERS: WellKnownProviderConfig[] = [
   {
     name: 'DeepSeek',
     category: 'General',
-    type: 'openai-chat-completion',
+    type: 'openai-responses',
     baseUrl: 'https://api.deepseek.com',
     completion: { baseUrl: '../beta' },
     balanceProvider: { method: 'deepseek' },

--- a/test/unit/plan4-provider-catalog.test.ts
+++ b/test/unit/plan4-provider-catalog.test.ts
@@ -67,6 +67,15 @@ describe('Plan 4 well-known catalog', () => {
     });
   });
 
+  it('uses Responses by default for DeepSeek', () => {
+    expect(
+      WELL_KNOWN_PROVIDERS.find((provider) => provider.name === 'DeepSeek'),
+    ).toMatchObject({
+      type: 'openai-responses',
+      baseUrl: 'https://api.deepseek.com',
+    });
+  });
+
   it('declares Zeta primary IDs, aliases, and only completion templates', () => {
     expect(getModel('zeta')).toMatchObject({
       completion: { templates: ['zeta1'] },


### PR DESCRIPTION
## Summary

- switch the built-in DeepSeek preset from OpenAI Chat Completions to OpenAI Responses
- keep the existing DeepSeek base URL, FIM beta endpoint, balance integration, and model list unchanged
- add a catalog regression test and update the English and Chinese manual configuration docs

## Rationale

DeepSeek's current official documentation states that its API supports the Responses API at `https://api.deepseek.com` and documents the supported stateless request/streaming format:

https://api-docs.deepseek.com/guides/responses_api/

The project already has a compatible OpenAI Responses provider. The built-in DeepSeek preset was still selecting `openai-chat-completion`, so one-click configuration could not use the newly supported interface by default.

## Validation

- `npx vitest run test/unit/plan4-provider-catalog.test.ts -t 'uses Responses by default for DeepSeek'` - passed
- `npm run compile` - passed
- `npm run verify:chat-lib` - passed
- `npm run l10n:check` - passed
- `git diff --check` - passed
- `npm run test:unit` - TypeScript and release checks passed; 103 test files and 1232 tests passed, with one pre-existing catalog assertion failing

The unchanged failing assertion expects every `deepseek-*` model to declare FIM. Current `main` added `deepseek-v4-flash-vision-exp` without a FIM template in commit `616a3bd`, so that existing assertion now fails independently of this patch. This PR deliberately leaves that unrelated catalog issue untouched.

Fixes #291
