### PR TITLE
fix: align GLM-5.3 reasoning configuration

### DIFF
--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -165,6 +165,55 @@ function modelIdentityIncludes(
   );
 }
 
+const GLM_5_3_MODEL_IDENTITIES = new Set(['glm-5.3', 'z-ai/glm-5.3']);
+const GLM_5_3_PROVIDER_ENDPOINTS = new Set([
+  'https://open.bigmodel.cn/api/paas/v4',
+  'https://open.bigmodel.cn/api/coding/paas/v4',
+  'https://api.z.ai/api/paas/v4',
+  'https://api.z.ai/api/coding/paas/v4',
+]);
+
+function isGlm53Model(model: { id: string; family?: string }): boolean {
+  const baseId = getBaseModelId(model.id).trim().toLowerCase();
+  const family = model.family?.trim().toLowerCase();
+  return (
+    GLM_5_3_MODEL_IDENTITIES.has(baseId) ||
+    (family !== undefined && GLM_5_3_MODEL_IDENTITIES.has(family))
+  );
+}
+
+function isOfficialGlm53Provider(provider: {
+  type: ProviderType;
+  baseUrl: string;
+}): boolean {
+  if (provider.type !== 'openai-chat-completion') {
+    return false;
+  }
+
+  try {
+    const url = new URL(provider.baseUrl);
+    if (
+      url.username !== '' ||
+      url.password !== '' ||
+      url.search !== '' ||
+      url.hash !== ''
+    ) {
+      return false;
+    }
+    const pathname = url.pathname.replace(/\/+$/, '');
+    return GLM_5_3_PROVIDER_ENDPOINTS.has(`${url.origin}${pathname}`);
+  } catch {
+    return false;
+  }
+}
+
+function isOfficialGlm53Request(
+  model: { id: string; family?: string },
+  provider: { type: ProviderType; baseUrl: string },
+): boolean {
+  return isGlm53Model(model) && isOfficialGlm53Provider(provider);
+}
+
 function isMoonshotOpenAIProvider(provider: { baseUrl: string }): boolean {
   return ['api.moonshot.cn', 'api.moonshot.ai'].some((pattern) =>
     matchProvider(provider.baseUrl, pattern),
@@ -645,7 +694,6 @@ export const FEATURES: Record<FeatureId, Feature> = {
         ]),
       (model) => modelFamilyIncludes(model, 'deepseek-v4'),
       (model) => modelFamilyIncludes(model, 'glm-5.2'),
-      (model) => modelFamilyIncludes(model, 'glm-5.3'),
     ],
   },
   [FeatureId.OpenAIUseThinkingParam2]: {
@@ -678,7 +726,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
     ],
   },
   [FeatureId.OpenAIUseGlm53ReasoningEffortParam]: {
-    customCheckers: [(model) => modelFamilyIncludes(model, 'glm-5.3')],
+    customCheckers: [isOfficialGlm53Request],
   },
   [FeatureId.OpenAIStripIncludeParam]: {
     supportedProviders: [

--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -286,6 +286,13 @@ export enum FeatureId {
    */
   OpenAIUseDeepSeekReasoningEffortParam = 'openai_use-deepseek-reasoning-effort-param',
   /**
+   * GLM-5.3 always reasons and accepts `low`, `high`, or `max` as its
+   * `reasoning_effort` value.
+   *
+   * @see https://docs.z.ai/guides/llm/glm-5.3
+   */
+  OpenAIUseGlm53ReasoningEffortParam = 'openai_use-glm-5.3-reasoning-effort-param',
+  /**
    * Using both the unofficial `thinking` and the `reasoning` fields in the OpenAI Responses API.
    *
    * @see https://www.volcengine.com/docs/82379/1569618?lang=zh
@@ -638,6 +645,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
         ]),
       (model) => modelFamilyIncludes(model, 'deepseek-v4'),
       (model) => modelFamilyIncludes(model, 'glm-5.2'),
+      (model) => modelFamilyIncludes(model, 'glm-5.3'),
     ],
   },
   [FeatureId.OpenAIUseThinkingParam2]: {
@@ -668,6 +676,9 @@ export const FEATURES: Record<FeatureId, Feature> = {
       (model) => modelFamilyIncludes(model, 'glm-5.2'),
       (model) => modelFamilyIncludes(model, 'deepseek-v4'),
     ],
+  },
+  [FeatureId.OpenAIUseGlm53ReasoningEffortParam]: {
+    customCheckers: [(model) => modelFamilyIncludes(model, 'glm-5.3')],
   },
   [FeatureId.OpenAIStripIncludeParam]: {
     supportedProviders: [

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -96,6 +96,7 @@ import {
  * - `openrouter_claude_adaptive_verbosity` — OpenRouter Claude adaptive thinking + top-level `verbosity`
  * - `thinking`                     — DeepSeek / MiMo / GLM `thinking: { type }` param
  * - `thinking_with_high_max_reasoning_effort` — GLM / DeepSeek V4 `thinking` + `reasoning_effort` (`high` / `max`)
+ * - `forced_thinking_with_reasoning_effort` — GLM-5.3 forced thinking + `reasoning_effort`
  * - `thinking_with_reasoning_effort` — VolcEngine `thinking` + `reasoning_effort`
  * - `disable_reasoning`            — Cerebras GLM `disable_reasoning` boolean
  * - `enable_thinking`              — Qwen / SiliconFlow `enable_thinking` boolean
@@ -108,6 +109,7 @@ type ReasoningParamType =
   | 'openrouter_claude_adaptive_verbosity'
   | 'thinking'
   | 'thinking_with_high_max_reasoning_effort'
+  | 'forced_thinking_with_reasoning_effort'
   | 'thinking_with_reasoning_effort'
   | 'official'
   | 'disable_reasoning'
@@ -736,6 +738,17 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
         };
       }
 
+      // GLM-5.3 — thinking is mandatory and `reasoning_effort` controls depth.
+      // @see https://docs.z.ai/guides/llm/glm-5.3
+      case 'forced_thinking_with_reasoning_effort': {
+        if (!thinking) {
+          return {};
+        }
+        return {
+          thinking: { type: 'enabled' },
+        };
+      }
+
       // VolcEngine — `thinking: { type }` + `reasoning_effort`
       // @see https://www.volcengine.com/docs/82379/1569618
       case 'thinking_with_reasoning_effort': {
@@ -855,6 +868,19 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       };
     }
 
+    if (type === 'forced_thinking_with_reasoning_effort') {
+      if (this.isThinkingDisabled(thinking)) {
+        return { reasoning_effort: 'low' };
+      }
+      return thinking.effort == null
+        ? {}
+        : {
+            reasoning_effort: this.normalizeReasoningEffortForGlm53(
+              thinking.effort,
+            ),
+          };
+    }
+
     if (type !== 'thinking_with_high_max_reasoning_effort') {
       return {};
     }
@@ -905,6 +931,24 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       case 'medium':
       case 'low':
       case 'minimal':
+      default:
+        return 'high';
+    }
+  }
+
+  private normalizeReasoningEffortForGlm53(
+    effort: NonNullable<NonNullable<ModelConfig['thinking']>['effort']>,
+  ): 'low' | 'high' | 'max' {
+    switch (effort) {
+      case 'none':
+      case 'minimal':
+      case 'low':
+        return 'low';
+      case 'xhigh':
+      case 'max':
+        return 'max';
+      case 'medium':
+      case 'high':
       default:
         return 'high';
     }
@@ -1016,6 +1060,11 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       this.config,
       model,
     );
+    const useGlm53ReasoningEffortParam = isFeatureSupported(
+      FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+      this.config,
+      model,
+    );
     const useTopK = isFeatureSupported(
       FeatureId.OpenAIUseTopK,
       this.config,
@@ -1083,11 +1132,13 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
     } else if (useReasoningParam) {
       thinkingParamType = 'reasoning';
     } else if (useThinkingParam) {
-      thinkingParamType = useDeepSeekReasoningEffortParam
-        ? 'thinking_with_high_max_reasoning_effort'
-        : useReasoningEffortParam
-          ? 'thinking_with_reasoning_effort'
-          : 'thinking';
+      thinkingParamType = useGlm53ReasoningEffortParam
+        ? 'forced_thinking_with_reasoning_effort'
+        : useDeepSeekReasoningEffortParam
+          ? 'thinking_with_high_max_reasoning_effort'
+          : useReasoningEffortParam
+            ? 'thinking_with_reasoning_effort'
+            : 'thinking';
     } else if (useDisableReasoningParam) {
       thinkingParamType = 'disable_reasoning';
     } else if (useThinkingParam3) {

--- a/src/well-known/models.ts
+++ b/src/well-known/models.ts
@@ -56,6 +56,7 @@ const OPENAI_OSS_REASONING_EFFORTS = ['high', 'medium', 'low'] as const;
 const TENCENT_HY3_REASONING_EFFORTS = ['high', 'medium', 'low'] as const;
 const DEEPSEEK_V4_REASONING_EFFORTS = ['max', 'high','low', 'none'] as const;
 const GLM_5_2_REASONING_EFFORTS = ['max', 'high', 'none'] as const;
+const GLM_5_3_REASONING_EFFORTS = ['max', 'high', 'low'] as const;
 const KIMI_K3_REASONING_EFFORTS = ['max', 'high', 'low'] as const;
 const NVIDIA_MINIMAX_REASONING_EFFORTS = [
   'high',
@@ -4287,7 +4288,7 @@ const _WELL_KNOWN_MODELS = [
       imageInput: false,
     },
     presetTemplates: [
-      openAiReasoningEffort(GLM_5_2_REASONING_EFFORTS, 'max'),
+      openAiReasoningEffort(GLM_5_3_REASONING_EFFORTS, 'max'),
     ],
   },
   {

--- a/test/unit/glm-5-3.test.ts
+++ b/test/unit/glm-5-3.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  buildBaseUrl: (baseUrl: string) => baseUrl,
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+}));
+
+vi.mock('../../src/client/definitions', () => ({
+  FeatureId: {},
+}));
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => undefined,
+}));
+
+vi.mock('../../src/utils', () => ({
+  isRawBaseUrlEnabled: () => false,
+}));
+
+import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+import {
+  applyPresetTemplateSelections,
+  buildPresetTemplateConfigurationSchema,
+} from '../../src/preset-templates';
+import type { ModelConfig } from '../../src/types';
+import { WELL_KNOWN_MODELS } from '../../src/well-known/models';
+import {
+  resolveProviderModels,
+  WELL_KNOWN_PROVIDERS,
+} from '../../src/well-known/providers';
+
+const GLM_5_3_REASONING_TYPE = 'forced_thinking_with_reasoning_effort';
+
+function requireModel(model: ModelConfig | undefined): ModelConfig {
+  if (model === undefined) {
+    throw new Error('GLM-5.3 model was not found');
+  }
+  return model;
+}
+
+function callPrivateBuilder(
+  provider: OpenAIChatCompletionProvider,
+  methodName: 'buildReasoningParams' | 'buildReasoningExtraBody',
+  model: ModelConfig,
+): unknown {
+  const builder: unknown = Reflect.get(provider, methodName);
+  if (typeof builder !== 'function') {
+    throw new Error(`${methodName} was not found`);
+  }
+  return Reflect.apply(builder, provider, [model, GLM_5_3_REASONING_TYPE]);
+}
+
+function getFeatureBlock(source: string, featureId: string): string {
+  const marker = `[FeatureId.${featureId}]: {`;
+  const start = source.indexOf(marker);
+  if (start < 0) {
+    throw new Error(`Feature ${featureId} was not found`);
+  }
+
+  const rest = source.slice(start);
+  const end = rest.indexOf('\n  },\n  [FeatureId.');
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe('GLM-5.3 catalog support', () => {
+  const model = WELL_KNOWN_MODELS.find(
+    (candidate) => candidate.id === 'glm-5.3',
+  );
+  const provider = new OpenAIChatCompletionProvider({
+    type: 'openai-chat-completion',
+    name: 'GLM-5.3 test',
+    baseUrl: 'https://api.z.ai/api/paas/v4',
+    models: [],
+  });
+
+  it('declares mandatory reasoning and the official limits', () => {
+    expect(model).toMatchObject({
+      id: 'glm-5.3',
+      name: 'GLM-5.3',
+      maxInputTokens: 1000000,
+      maxOutputTokens: 128000,
+      stream: true,
+      thinking: {
+        type: 'enabled',
+        effort: 'max',
+      },
+      capabilities: {
+        toolCalling: true,
+        imageInput: false,
+      },
+    });
+  });
+
+  it('generates only the three supported reasoning effort choices', () => {
+    const glm53 = requireModel(model);
+    const effortTemplate = glm53.presetTemplates?.find(
+      (template) => template.id === 'reasoningEffort',
+    );
+
+    expect(effortTemplate?.default).toBe('max');
+    expect(effortTemplate?.presets.map((preset) => preset.id)).toEqual([
+      'max',
+      'high',
+      'low',
+    ]);
+    expect(
+      buildPresetTemplateConfigurationSchema(glm53)?.properties?.[
+        'reasoningEffort'
+      ],
+    ).toMatchObject({
+      enum: ['max', 'high', 'low'],
+      default: 'max',
+    });
+    expect(
+      applyPresetTemplateSelections(glm53, { reasoningEffort: 'low' }).thinking,
+    ).toEqual({ type: 'enabled', effort: 'low' });
+  });
+
+  it.each(['ZhiPu AI', 'ZhiPu AI (Coding Plan)', 'Z.AI', 'Z.AI (Coding Plan)'])(
+    'generates the corrected model for the %s built-in provider',
+    (providerName) => {
+      const definition = WELL_KNOWN_PROVIDERS.find(
+        (candidate) => candidate.name === providerName,
+      );
+      if (definition === undefined) {
+        throw new Error(`${providerName} provider was not found`);
+      }
+
+      const generated = resolveProviderModels(definition).find(
+        (candidate) => candidate.id === 'glm-5.3',
+      );
+      const template = generated?.presetTemplates?.find(
+        (candidate) => candidate.id === 'reasoningEffort',
+      );
+
+      expect(generated?.thinking).toEqual({ type: 'enabled', effort: 'max' });
+      expect(template?.presets.map((preset) => preset.id)).toEqual([
+        'max',
+        'high',
+        'low',
+      ]);
+    },
+  );
+
+  it.each(['max', 'high', 'low'] as const)(
+    'sends mandatory thinking with %s reasoning effort',
+    (effort) => {
+      const configured = applyPresetTemplateSelections(requireModel(model), {
+        reasoningEffort: effort,
+      });
+
+      expect(
+        callPrivateBuilder(provider, 'buildReasoningParams', configured),
+      ).toEqual({ thinking: { type: 'enabled' } });
+      expect(
+        callPrivateBuilder(provider, 'buildReasoningExtraBody', configured),
+      ).toEqual({ reasoning_effort: effort });
+    },
+  );
+
+  it('converts a stale disabled configuration to enabled low reasoning', () => {
+    const configured = {
+      ...requireModel(model),
+      thinking: { type: 'disabled' as const },
+    };
+
+    expect(
+      callPrivateBuilder(provider, 'buildReasoningParams', configured),
+    ).toEqual({ thinking: { type: 'enabled' } });
+    expect(
+      callPrivateBuilder(provider, 'buildReasoningExtraBody', configured),
+    ).toEqual({ reasoning_effort: 'low' });
+  });
+
+  it('enables the GLM-5.3 thinking and reasoning effort feature gates', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/client/definitions.ts'),
+      'utf8',
+    );
+
+    expect(getFeatureBlock(source, 'OpenAIUseThinkingParam')).toContain(
+      "modelFamilyIncludes(model, 'glm-5.3')",
+    );
+    expect(
+      getFeatureBlock(source, 'OpenAIUseGlm53ReasoningEffortParam'),
+    ).toContain("modelFamilyIncludes(model, 'glm-5.3')");
+  });
+});

--- a/test/unit/glm-5-3.test.ts
+++ b/test/unit/glm-5-3.test.ts
@@ -1,48 +1,156 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import type {
+  ChatRequestTrace,
+  ModelConfig,
+  ProviderConfig,
+} from '../../src/types';
 
-vi.mock('vscode', () => ({
-  env: { language: 'en' },
-  l10n: {
-    t: (message: string | { message: string }) =>
-      typeof message === 'string' ? message : message.message,
-  },
+const network = vi.hoisted(() => ({
+  requests: [] as Array<{ url: string; body: unknown }>,
 }));
 
-vi.mock('../../src/client/utils', () => ({
-  buildBaseUrl: (baseUrl: string) => baseUrl,
-  matchProvider: (url: string, pattern: string | RegExp) =>
-    typeof pattern === 'string'
-      ? url.includes(pattern.replaceAll('*', ''))
-      : pattern.test(url),
-}));
+vi.mock('vscode', () => {
+  class EventEmitter<T> {
+    readonly event = (
+      _listener: (value: T) => unknown,
+    ): { dispose: () => void } => ({ dispose: () => undefined });
+    fire(_value: T): void {}
+    dispose(): void {}
+  }
 
-vi.mock('../../src/client/definitions', () => ({
-  FeatureId: {},
-}));
+  class LanguageModelTextPart {
+    constructor(readonly value: string) {}
+  }
 
-vi.mock('../../src/logger', () => ({
-  createSimpleHttpLogger: () => undefined,
-}));
+  class LanguageModelDataPart {
+    constructor(
+      readonly data: Uint8Array,
+      readonly mimeType: string,
+    ) {}
+  }
 
-vi.mock('../../src/utils', () => ({
-  isRawBaseUrlEnabled: () => false,
-}));
+  class LanguageModelThinkingPart {
+    constructor(
+      readonly value: string | string[],
+      readonly id?: string,
+      readonly metadata?: object,
+    ) {}
+  }
 
+  class LanguageModelToolCallPart {
+    constructor(
+      readonly callId: string,
+      readonly name: string,
+      readonly input: object,
+    ) {}
+  }
+
+  class LanguageModelToolResultPart {}
+  class LanguageModelToolResultPart2 {}
+  class ThemeIcon {
+    constructor(readonly id: string) {}
+  }
+
+  return {
+    env: { language: 'en' },
+    EventEmitter,
+    extensions: { getExtension: () => undefined },
+    l10n: {
+      t: (message: string | { message: string }) =>
+        typeof message === 'string' ? message : message.message,
+    },
+    LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelChatToolMode: { Auto: 1, Required: 2 },
+    LanguageModelDataPart,
+    LanguageModelTextPart,
+    LanguageModelThinkingPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelToolResultPart2,
+    ThemeIcon,
+    workspace: {
+      getConfiguration: () => ({
+        get: (_key: string, fallback?: unknown) => fallback,
+      }),
+    },
+  };
+});
+
+vi.mock('../../src/logger', () => {
+  class RequestLogger {
+    constructor(readonly requestId: string) {}
+    providerRequest(): void {}
+    providerResponseMeta(): void {}
+    providerResponseBody(): void {}
+    providerResponseChunk(): void {}
+    retry(): void {}
+    usage(): void {}
+    verbose(): void {}
+  }
+
+  return {
+    RequestLogger,
+    createSimpleHttpLogger: () => undefined,
+  };
+});
+
+vi.mock('../../src/client/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/client/utils')>();
+  return {
+    ...actual,
+    createCustomFetch:
+      () =>
+      async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const body =
+          typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+        network.requests.push({ url: input.toString(), body });
+        return new Response(
+          JSON.stringify({
+            id: 'chatcmpl_glm_5_3_test',
+            object: 'chat.completion',
+            created: 0,
+            model: 'glm-5.3',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'ok' },
+                finish_reason: 'stop',
+                logprobs: null,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      },
+  };
+});
+
+import * as vscode from 'vscode';
+import { FeatureId } from '../../src/client/definitions';
 import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+import { isFeatureSupported } from '../../src/client/utils';
+import { RequestLogger } from '../../src/logger';
 import {
   applyPresetTemplateSelections,
   buildPresetTemplateConfigurationSchema,
 } from '../../src/preset-templates';
-import type { ModelConfig } from '../../src/types';
 import { WELL_KNOWN_MODELS } from '../../src/well-known/models';
 import {
   resolveProviderModels,
   WELL_KNOWN_PROVIDERS,
 } from '../../src/well-known/providers';
 
-const GLM_5_3_REASONING_TYPE = 'forced_thinking_with_reasoning_effort';
+const OFFICIAL_ENDPOINTS = [
+  'https://open.bigmodel.cn/api/paas/v4',
+  'https://open.bigmodel.cn/api/coding/paas/v4',
+  'https://api.z.ai/api/paas/v4',
+  'https://api.z.ai/api/coding/paas/v4',
+] as const;
+
+const cancellationToken: vscode.CancellationToken = {
+  isCancellationRequested: false,
+  onCancellationRequested: () => ({ dispose: () => undefined }),
+};
 
 function requireModel(model: ModelConfig | undefined): ModelConfig {
   if (model === undefined) {
@@ -51,40 +159,73 @@ function requireModel(model: ModelConfig | undefined): ModelConfig {
   return model;
 }
 
-function callPrivateBuilder(
-  provider: OpenAIChatCompletionProvider,
-  methodName: 'buildReasoningParams' | 'buildReasoningExtraBody',
-  model: ModelConfig,
-): unknown {
-  const builder: unknown = Reflect.get(provider, methodName);
-  if (typeof builder !== 'function') {
-    throw new Error(`${methodName} was not found`);
-  }
-  return Reflect.apply(builder, provider, [model, GLM_5_3_REASONING_TYPE]);
+function providerConfig(baseUrl: string): ProviderConfig {
+  return {
+    type: 'openai-chat-completion',
+    name: 'GLM-5.3 test',
+    baseUrl,
+    models: [],
+  };
 }
 
-function getFeatureBlock(source: string, featureId: string): string {
-  const marker = `[FeatureId.${featureId}]: {`;
-  const start = source.indexOf(marker);
-  if (start < 0) {
-    throw new Error(`Feature ${featureId} was not found`);
+function trace(): ChatRequestTrace {
+  return {
+    performance: {
+      tts: Date.now(),
+      ttf: 0,
+      ttft: 0,
+      tps: 0,
+      tl: 0,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function serializeRequest(
+  baseUrl: string,
+  model: ModelConfig,
+): Promise<Record<string, unknown>> {
+  network.requests.length = 0;
+  const provider = new OpenAIChatCompletionProvider(providerConfig(baseUrl));
+  const messages: vscode.LanguageModelChatRequestMessage[] = [
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      content: [new vscode.LanguageModelTextPart('hello')],
+      name: undefined,
+    },
+  ];
+
+  for await (const _part of provider.streamChat(
+    `test/${model.id}`,
+    { ...model, stream: false },
+    messages,
+    {
+      requestInitiator: 'test',
+      toolMode: vscode.LanguageModelChatToolMode.Auto,
+    },
+    trace(),
+    cancellationToken,
+    new RequestLogger('glm-5.3-test'),
+    { kind: 'token', token: 'test-key' },
+  )) {
+    // Consume the response so the complete request path runs.
   }
 
-  const rest = source.slice(start);
-  const end = rest.indexOf('\n  },\n  [FeatureId.');
-  return end < 0 ? rest : rest.slice(0, end);
+  expect(network.requests).toHaveLength(1);
+  const body = network.requests[0]?.body;
+  if (!isRecord(body)) {
+    throw new Error('Serialized request body was not an object');
+  }
+  return body;
 }
 
 describe('GLM-5.3 catalog support', () => {
   const model = WELL_KNOWN_MODELS.find(
     (candidate) => candidate.id === 'glm-5.3',
   );
-  const provider = new OpenAIChatCompletionProvider({
-    type: 'openai-chat-completion',
-    name: 'GLM-5.3 test',
-    baseUrl: 'https://api.z.ai/api/paas/v4',
-    models: [],
-  });
 
   it('declares mandatory reasoning and the official limits', () => {
     expect(model).toMatchObject({
@@ -93,14 +234,8 @@ describe('GLM-5.3 catalog support', () => {
       maxInputTokens: 1000000,
       maxOutputTokens: 128000,
       stream: true,
-      thinking: {
-        type: 'enabled',
-        effort: 'max',
-      },
-      capabilities: {
-        toolCalling: true,
-        imageInput: false,
-      },
+      thinking: { type: 'enabled', effort: 'max' },
+      capabilities: { toolCalling: true, imageInput: false },
     });
   });
 
@@ -120,13 +255,7 @@ describe('GLM-5.3 catalog support', () => {
       buildPresetTemplateConfigurationSchema(glm53)?.properties?.[
         'reasoningEffort'
       ],
-    ).toMatchObject({
-      enum: ['max', 'high', 'low'],
-      default: 'max',
-    });
-    expect(
-      applyPresetTemplateSelections(glm53, { reasoningEffort: 'low' }).thinking,
-    ).toEqual({ type: 'enabled', effort: 'low' });
+    ).toMatchObject({ enum: ['max', 'high', 'low'], default: 'max' });
   });
 
   it.each(['ZhiPu AI', 'ZhiPu AI (Coding Plan)', 'Z.AI', 'Z.AI (Coding Plan)'])(
@@ -142,60 +271,176 @@ describe('GLM-5.3 catalog support', () => {
       const generated = resolveProviderModels(definition).find(
         (candidate) => candidate.id === 'glm-5.3',
       );
-      const template = generated?.presetTemplates?.find(
-        (candidate) => candidate.id === 'reasoningEffort',
-      );
-
       expect(generated?.thinking).toEqual({ type: 'enabled', effort: 'max' });
-      expect(template?.presets.map((preset) => preset.id)).toEqual([
-        'max',
-        'high',
-        'low',
-      ]);
+      expect(
+        generated?.presetTemplates?.[0]?.presets.map((preset) => preset.id),
+      ).toEqual(['max', 'high', 'low']);
+    },
+  );
+});
+
+describe('GLM-5.3 feature boundaries', () => {
+  const model = requireModel(
+    WELL_KNOWN_MODELS.find((candidate) => candidate.id === 'glm-5.3'),
+  );
+
+  it.each(OFFICIAL_ENDPOINTS)(
+    'enables the dedicated protocol on %s',
+    (baseUrl) => {
+      expect(
+        isFeatureSupported(
+          FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+          providerConfig(baseUrl),
+          model,
+        ),
+      ).toBe(true);
     },
   );
 
-  it.each(['max', 'high', 'low'] as const)(
-    'sends mandatory thinking with %s reasoning effort',
-    (effort) => {
-      const configured = applyPresetTemplateSelections(requireModel(model), {
-        reasoningEffort: effort,
-      });
-
+  it.each([
+    { id: 'glm-5.3', family: 'glm-5' },
+    { id: 'z-ai/glm-5.3' },
+    { id: 'other-id', family: 'glm-5.3' },
+  ] satisfies Array<Pick<ModelConfig, 'id' | 'family'>>)(
+    'accepts the exact base ID or family identity: $id / $family',
+    (identity) => {
       expect(
-        callPrivateBuilder(provider, 'buildReasoningParams', configured),
-      ).toEqual({ thinking: { type: 'enabled' } });
-      expect(
-        callPrivateBuilder(provider, 'buildReasoningExtraBody', configured),
-      ).toEqual({ reasoning_effort: effort });
+        isFeatureSupported(
+          FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+          providerConfig(OFFICIAL_ENDPOINTS[0]),
+          { ...model, ...identity },
+        ),
+      ).toBe(true);
     },
   );
 
-  it('converts a stale disabled configuration to enabled low reasoning', () => {
-    const configured = {
-      ...requireModel(model),
-      thinking: { type: 'disabled' as const },
-    };
+  it.each([
+    { id: 'glm-5.2' },
+    { id: 'glm-5.1' },
+    { id: 'glm-5.30' },
+    { id: 'vendor/glm-5.3' },
+    { id: 'z-ai/glm-5.3-pro' },
+    { id: 'other-id', family: 'glm-5' },
+    { id: 'other-id', family: 'glm-5.30' },
+    { id: 'other-id', family: 'vendor/glm-5.3' },
+  ] satisfies Array<Pick<ModelConfig, 'id' | 'family'>>)(
+    'rejects non-GLM-5.3 identity: $id / $family',
+    (identity) => {
+      expect(
+        isFeatureSupported(
+          FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+          providerConfig(OFFICIAL_ENDPOINTS[0]),
+          { ...model, ...identity },
+        ),
+      ).toBe(false);
+    },
+  );
 
+  it.each([
+    'https://third-party.example/v1',
+    'https://api.z.ai.example/api/paas/v4',
+    'https://api.z.ai/api/v1',
+    'https://api.z.ai/api/paas/v4?route=other',
+  ])('rejects non-official endpoint %s', (baseUrl) => {
     expect(
-      callPrivateBuilder(provider, 'buildReasoningParams', configured),
-    ).toEqual({ thinking: { type: 'enabled' } });
-    expect(
-      callPrivateBuilder(provider, 'buildReasoningExtraBody', configured),
-    ).toEqual({ reasoning_effort: 'low' });
+      isFeatureSupported(
+        FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+        providerConfig(baseUrl),
+        model,
+      ),
+    ).toBe(false);
   });
 
-  it('enables the GLM-5.3 thinking and reasoning effort feature gates', () => {
-    const source = readFileSync(
-      resolve(process.cwd(), 'src/client/definitions.ts'),
-      'utf8',
-    );
-
-    expect(getFeatureBlock(source, 'OpenAIUseThinkingParam')).toContain(
-      "modelFamilyIncludes(model, 'glm-5.3')",
-    );
+  it('rejects a different provider protocol at an official endpoint', () => {
     expect(
-      getFeatureBlock(source, 'OpenAIUseGlm53ReasoningEffortParam'),
-    ).toContain("modelFamilyIncludes(model, 'glm-5.3')");
+      isFeatureSupported(
+        FeatureId.OpenAIUseGlm53ReasoningEffortParam,
+        {
+          ...providerConfig(OFFICIAL_ENDPOINTS[0]),
+          type: 'openai-responses',
+        },
+        model,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('GLM-5.3 serialized requests', () => {
+  const model = requireModel(
+    WELL_KNOWN_MODELS.find((candidate) => candidate.id === 'glm-5.3'),
+  );
+
+  it.each(OFFICIAL_ENDPOINTS)(
+    'serializes mandatory max reasoning on %s',
+    async (baseUrl) => {
+      const body = await serializeRequest(baseUrl, model);
+      expect(body['thinking']).toEqual({ type: 'enabled' });
+      expect(body['reasoning_effort']).toBe('max');
+    },
+  );
+
+  it('serializes the explicit Z.AI model alias', async () => {
+    const body = await serializeRequest(OFFICIAL_ENDPOINTS[0], {
+      ...model,
+      id: 'z-ai/glm-5.3',
+    });
+    expect(body).toMatchObject({
+      model: 'z-ai/glm-5.3',
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'max',
+    });
+  });
+
+  it.each([
+    { type: 'disabled' as const },
+    { type: 'enabled' as const, effort: 'none' as const },
+  ])(
+    'migrates stale $type / $effort reasoning to enabled low',
+    async (thinking) => {
+      const body = await serializeRequest(OFFICIAL_ENDPOINTS[0], {
+        ...model,
+        thinking,
+      });
+      expect(body['thinking']).toEqual({ type: 'enabled' });
+      expect(body['reasoning_effort']).toBe('low');
+    },
+  );
+
+  it('serializes a selected low effort without rewriting it', async () => {
+    const configured = applyPresetTemplateSelections(model, {
+      reasoningEffort: 'low',
+    });
+    const body = await serializeRequest(OFFICIAL_ENDPOINTS[0], configured);
+    expect(body['thinking']).toEqual({ type: 'enabled' });
+    expect(body['reasoning_effort']).toBe('low');
+  });
+
+  it.each([
+    { id: 'glm-5.2' },
+    { id: 'glm-5.1' },
+    { id: 'glm-5.30' },
+    { id: 'vendor/glm-5.3' },
+    { id: 'other-id', family: 'glm-5.30' },
+    { id: 'other-id', family: 'vendor/glm-5.3' },
+  ] satisfies Array<Pick<ModelConfig, 'id' | 'family'>>)(
+    'does not force thinking for a non-GLM-5.3 identity: $id / $family',
+    async (identity) => {
+      const body = await serializeRequest(OFFICIAL_ENDPOINTS[0], {
+        ...model,
+        ...identity,
+        thinking: { type: 'disabled' },
+      });
+      expect(body['thinking']).toEqual({ type: 'disabled' });
+      expect(body['reasoning_effort']).toBeUndefined();
+    },
+  );
+
+  it('does not use the forced protocol on a third-party endpoint', async () => {
+    const body = await serializeRequest('https://third-party.example/v1', {
+      ...model,
+      thinking: { type: 'disabled' },
+    });
+    expect(body['thinking']).toBeUndefined();
+    expect(body['reasoning_effort']).toBe('none');
   });
 });


### PR DESCRIPTION
## Summary

- expose only the official `max`, `high`, and `low` reasoning effort choices for GLM-5.3
- route GLM-5.3 requests through a dedicated forced-thinking protocol so `reasoning_effort` reaches the API
- translate stale disabled/no-reasoning configurations to `thinking.type=enabled` with low effort instead of sending an unsupported value
- cover all four built-in ZhiPu/Z.AI provider definitions and the final request parameters

## Verification

- `vitest run test/unit/glm-5-3.test.ts`: 11 passed
- strict TypeScript checks for source and tests: passed
- all tests except `test/unit/plan4-provider-catalog.test.ts`: 1,236 passed across 104 files
- the excluded Plan 4 assertion fails identically on unmodified `main@616a3bd` because the newly added DeepSeek vision model has no FIM template

Fixes #296
