### PR TITLE
feat: support MiniMax Token Plan quotas

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -810,7 +810,7 @@
   "Monitor usage percentages via Gemini CLI retrieveUserQuota API": "Monitor usage percentages via Gemini CLI retrieveUserQuota API",
   "Monitor usage percentages via Codex usage APIs": "Monitor usage percentages via Codex usage APIs",
   "Monitor subscription and tool usage quotas via Synthetic API": "Monitor subscription and tool usage quotas via Synthetic API",
-  "Monitor balance via MiniMax coding plan API": "Monitor balance via MiniMax coding plan API",
+  "Monitor MiniMax Token Plan and Coding Plan quotas": "Monitor MiniMax Token Plan and Coding Plan quotas",
   "Moonshot AI Balance": "Moonshot AI Balance",
   "New API Balance": "New API Balance",
   "New API Balance Configuration": "New API Balance Configuration",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -810,7 +810,7 @@
   "Monitor usage percentages via Gemini CLI retrieveUserQuota API": "通过 Gemini CLI retrieveUserQuota API 监控用量百分比",
   "Monitor usage percentages via Codex usage APIs": "通过 Codex usage API 监控用量百分比",
   "Monitor subscription and tool usage quotas via Synthetic API": "通过 Synthetic API 监控订阅与工具调用配额",
-  "Monitor balance via MiniMax coding plan API": "通过 MiniMax coding plan API 监控余额",
+  "Monitor MiniMax Token Plan and Coding Plan quotas": "监控 MiniMax Token Plan 和 Coding Plan 配额",
   "Moonshot AI Balance": "Moonshot AI 余额",
   "New API Balance": "New API 余额",
   "New API Balance Configuration": "New API 余额配置",

--- a/src/balance/balance-manager.ts
+++ b/src/balance/balance-manager.ts
@@ -1112,6 +1112,7 @@ export class BalanceManager implements vscode.Disposable {
     if (type === 'percent') {
       const value = this.toFiniteNumber(raw.value);
       const basis = this.toPercentBasis(raw.basis);
+      const displayMaximum = this.toFiniteNumber(raw.displayMaximum);
       if (value === undefined) {
         return undefined;
       }
@@ -1121,6 +1122,9 @@ export class BalanceManager implements vscode.Disposable {
         type,
         value,
         ...(basis ? { basis } : {}),
+        ...(displayMaximum !== undefined && displayMaximum >= 100
+          ? { displayMaximum }
+          : {}),
       };
     }
 

--- a/src/balance/definitions.ts
+++ b/src/balance/definitions.ts
@@ -223,7 +223,7 @@ export const BALANCE_METHODS = {
   minimax: {
     id: 'minimax',
     label: t('MiniMax Balance'),
-    description: t('Monitor balance via MiniMax coding plan API'),
+    description: t('Monitor MiniMax Token Plan and Coding Plan quotas'),
     category: 'General',
     ctor: MiniMaxBalanceProvider,
     supportsSensitiveDataInSettings:

--- a/src/balance/display.ts
+++ b/src/balance/display.ts
@@ -33,11 +33,30 @@ function formatIntegerAmount(value: number): string {
   return Math.round(value).toLocaleString();
 }
 
-function formatPercent(value: number): string {
-  return `${clampPercent(value).toLocaleString(undefined, {
+function formatPercent(value: number, displayMaximum = 100): string {
+  const maximum =
+    Number.isFinite(displayMaximum) && displayMaximum >= 100
+      ? displayMaximum
+      : 100;
+  const normalized = Number.isFinite(value)
+    ? Math.max(0, Math.min(maximum, value))
+    : 0;
+  return `${normalized.toLocaleString(undefined, {
     minimumFractionDigits: 0,
     maximumFractionDigits: PERCENT_FRACTION_DIGITS,
   })}%`;
+}
+
+function resolvePercentDisplayMaximum(metric: BalancePercentMetric): number {
+  return metric.displayMaximum !== undefined &&
+    Number.isFinite(metric.displayMaximum) &&
+    metric.displayMaximum >= 100
+    ? metric.displayMaximum
+    : 100;
+}
+
+function formatPercentMetric(metric: BalancePercentMetric): string {
+  return formatPercent(metric.value, resolvePercentDisplayMaximum(metric));
 }
 
 function resolveTimeText(metric: BalanceTimeMetric): string {
@@ -853,7 +872,14 @@ function formatGroupLine(group: MetricLineGroup): string | undefined {
   }
   const statusMetric = pickStatusMetric(group.metrics);
   const timeMetric = pickTimeMetric(group.metrics);
+  const percentMetric = pickPercentMetric(group.metrics);
   const percent = resolveGroupPercent(group.metrics, amount, token);
+  const extendedRemainingPercent =
+    percentMetric &&
+    percentMetric.basis !== 'used' &&
+    resolvePercentDisplayMaximum(percentMetric) > 100
+      ? formatPercentMetric(percentMetric)
+      : undefined;
 
   let value: string | undefined;
   let valueSource:
@@ -873,6 +899,9 @@ function formatGroupLine(group: MetricLineGroup): string | undefined {
   } else if (statusMetric) {
     value = resolveStatusText(statusMetric);
     valueSource = 'status';
+  } else if (extendedRemainingPercent) {
+    value = `${extendedRemainingPercent} ${t('remaining')}`;
+    valueSource = 'percent';
   } else if (percent !== undefined) {
     value = `${formatPercent(percent)} / ${formatPercent(100)}`;
     valueSource = 'percent';
@@ -890,9 +919,10 @@ function formatGroupLine(group: MetricLineGroup): string | undefined {
   const usedPercentText =
     percent !== undefined ? formatPercent(percent) : undefined;
   const remainingPercentText =
-    percent !== undefined
+    extendedRemainingPercent ??
+    (percent !== undefined
       ? formatPercent(clampPercent(100 - percent))
-      : undefined;
+      : undefined);
   const shouldPrefixPercentInTitle = valueSource !== 'percent';
   const title = quotaLike
     ? shouldPrefixPercentInTitle && remainingPercentText
@@ -1022,7 +1052,7 @@ export function formatMetricValue(metric: BalanceMetric): string | undefined {
     return formatIntegerAmount(metric.value);
   }
   if (metric.type === 'percent') {
-    return formatPercent(metric.value);
+    return formatPercentMetric(metric);
   }
   if (metric.type === 'time') {
     return resolveTimeText(metric);

--- a/src/balance/providers/minimax.ts
+++ b/src/balance/providers/minimax.ts
@@ -78,14 +78,37 @@ function parseErrorMessage(text: string): string | undefined {
 
 const MINIMAX_TOKEN_PLAN_PATH = '/v1/token_plan/remains';
 const MINIMAX_CODING_PLAN_PATH = '/v1/api/openplatform/coding_plan/remains';
+// Match the MiniMax CLI ceiling so boosted quota text stays readable.
+const MINIMAX_WEEKLY_PERCENT_DISPLAY_MAXIMUM = 200;
+const MINIMAX_GLOBAL_HOSTS = new Set([
+  'minimax.io',
+  'api.minimax.io',
+  'platform.minimax.io',
+  'www.minimax.io',
+]);
+const MINIMAX_CHINA_HOSTS = new Set([
+  'minimaxi.com',
+  'api.minimaxi.com',
+  'platform.minimaxi.com',
+  'www.minimaxi.com',
+]);
 
 export function resolveMiniMaxTokenPlanEndpoint(baseUrl: string): string {
-  const hostname = new URL(baseUrl).hostname.toLowerCase();
-  const tokenPlanHost =
-    hostname === 'minimaxi.com' || hostname.endsWith('.minimaxi.com')
-      ? 'www.minimaxi.com'
-      : 'www.minimax.io';
-  return new URL(MINIMAX_TOKEN_PLAN_PATH, `https://${tokenPlanHost}`).toString();
+  const base = new URL(baseUrl);
+  const hostname = base.hostname.toLowerCase();
+  if (MINIMAX_GLOBAL_HOSTS.has(hostname)) {
+    return new URL(
+      MINIMAX_TOKEN_PLAN_PATH,
+      'https://www.minimax.io',
+    ).toString();
+  }
+  if (MINIMAX_CHINA_HOSTS.has(hostname)) {
+    return new URL(
+      MINIMAX_TOKEN_PLAN_PATH,
+      'https://www.minimaxi.com',
+    ).toString();
+  }
+  return new URL(MINIMAX_TOKEN_PLAN_PATH, base).toString();
 }
 
 export function resolveMiniMaxCodingPlanEndpoint(baseUrl: string): string {
@@ -176,6 +199,7 @@ interface MiniMaxWindowDefinition {
   remainingPercentKey: string;
   endTimeKey: string;
   statusKey: string;
+  boostPermilleKey?: string;
 }
 
 function parseTokenPlanWindow(
@@ -191,6 +215,9 @@ function parseTokenPlanWindow(
   );
   const endTime = pickNumberLike(model, definition.endTimeKey);
   const status = pickNumberLike(model, definition.statusKey);
+  const boostPermille = definition.boostPermilleKey
+    ? pickNumberLike(model, definition.boostPermilleKey)
+    : undefined;
   const hasCountQuota = total !== undefined && total > 0;
   const remaining =
     hasCountQuota && rawRemaining !== undefined
@@ -201,12 +228,20 @@ function parseTokenPlanWindow(
     : remaining !== undefined && total !== undefined
       ? (remaining / total) * 100
       : undefined;
+  const boostedRemainingPercent =
+    remainingPercent !== undefined && boostPermille !== undefined
+      ? Math.min(
+          MINIMAX_WEEKLY_PERCENT_DISPLAY_MAXIMUM,
+          remainingPercent * (Math.max(0, boostPermille) / 1000),
+        )
+      : remainingPercent;
+  const isUnlimited = status === 3;
   const metricContext = {
     period: definition.period,
     label: definition.label,
   } as const;
 
-  if (remaining !== undefined && total !== undefined) {
+  if (!isUnlimited && remaining !== undefined && total !== undefined) {
     items.push(
       {
         id: `${definition.id}-remaining`,
@@ -232,20 +267,23 @@ function parseTokenPlanWindow(
     );
   }
 
-  if (status === 3 && !hasCountQuota) {
+  if (isUnlimited) {
     items.push({
       id: `${definition.id}-status`,
       type: 'status',
       ...metricContext,
       value: 'unlimited',
     });
-  } else if (remainingPercent !== undefined) {
+  } else if (boostedRemainingPercent !== undefined) {
     items.push({
       id: `${definition.id}-remaining-percent`,
       type: 'percent',
       ...metricContext,
-      value: remainingPercent,
+      value: boostedRemainingPercent,
       basis: 'remaining',
+      ...(boostedRemainingPercent > 100
+        ? { displayMaximum: MINIMAX_WEEKLY_PERCENT_DISPLAY_MAXIMUM }
+        : {}),
     });
   } else if (status === 2) {
     items.push({
@@ -305,6 +343,7 @@ export function parseMiniMaxTokenPlanSnapshot(
     remainingPercentKey: 'current_weekly_remaining_percent',
     endTimeKey: 'weekly_end_time',
     statusKey: 'current_weekly_status',
+    boostPermilleKey: 'weekly_boost_permille',
   });
   const items = [...intervalItems, ...weeklyItems];
   if (items.length === 0) {

--- a/src/balance/providers/minimax.ts
+++ b/src/balance/providers/minimax.ts
@@ -5,6 +5,7 @@ import { fetchWithRetry } from '../../utils';
 import type { SecretStore } from '../../secret';
 import type {
   BalanceConfig,
+  BalanceMetric,
   BalanceRefreshInput,
   BalanceRefreshResult,
   BalanceSnapshot,
@@ -75,10 +76,332 @@ function parseErrorMessage(text: string): string | undefined {
   return normalized;
 }
 
-const MINIMAX_BALANCE_PATH = '/v1/api/openplatform/coding_plan/remains';
+const MINIMAX_TOKEN_PLAN_PATH = '/v1/token_plan/remains';
+const MINIMAX_CODING_PLAN_PATH = '/v1/api/openplatform/coding_plan/remains';
 
-function resolveMiniMaxBalanceEndpoint(baseUrl: string): string {
-  return new URL(MINIMAX_BALANCE_PATH, baseUrl).toString();
+export function resolveMiniMaxTokenPlanEndpoint(baseUrl: string): string {
+  const hostname = new URL(baseUrl).hostname.toLowerCase();
+  const tokenPlanHost =
+    hostname === 'minimaxi.com' || hostname.endsWith('.minimaxi.com')
+      ? 'www.minimaxi.com'
+      : 'www.minimax.io';
+  return new URL(MINIMAX_TOKEN_PLAN_PATH, `https://${tokenPlanHost}`).toString();
+}
+
+export function resolveMiniMaxCodingPlanEndpoint(baseUrl: string): string {
+  return new URL(MINIMAX_CODING_PLAN_PATH, baseUrl).toString();
+}
+
+function isValidPercent(value: number | undefined): value is number {
+  return value !== undefined && value >= 0 && value <= 100;
+}
+
+function isValidTimestamp(value: number | undefined): value is number {
+  return value !== undefined && value > 0;
+}
+
+function hasQuotaWindow(model: Record<string, unknown>): boolean {
+  const intervalPercent = pickNumberLike(
+    model,
+    'current_interval_remaining_percent',
+  );
+  const weeklyPercent = pickNumberLike(
+    model,
+    'current_weekly_remaining_percent',
+  );
+  const intervalTotal = pickNumberLike(model, 'current_interval_total_count');
+  const weeklyTotal = pickNumberLike(model, 'current_weekly_total_count');
+  return (
+    isValidPercent(intervalPercent) ||
+    isValidPercent(weeklyPercent) ||
+    (intervalTotal !== undefined && intervalTotal > 0) ||
+    (weeklyTotal !== undefined && weeklyTotal > 0)
+  );
+}
+
+function isUnavailableQuotaModel(model: Record<string, unknown>): boolean {
+  return (
+    pickNumberLike(model, 'current_interval_total_count') === 0 &&
+    pickNumberLike(model, 'current_weekly_total_count') === 0 &&
+    pickNumberLike(model, 'current_interval_status') === 3 &&
+    pickNumberLike(model, 'current_weekly_status') === 3
+  );
+}
+
+function isCodingQuotaModel(model: Record<string, unknown>): boolean {
+  const name = pickString(model, 'model_name')?.trim().toLowerCase();
+  if (!name) {
+    return false;
+  }
+  return (
+    name === 'general' ||
+    name === 'text' ||
+    name.startsWith('minimax-') ||
+    name.startsWith('minimax_m')
+  );
+}
+
+function hasFiveHourWindow(model: Record<string, unknown>): boolean {
+  const startTime = pickNumberLike(model, 'start_time');
+  const endTime = pickNumberLike(model, 'end_time');
+  if (startTime === undefined || endTime === undefined) {
+    return false;
+  }
+  const durationMs = endTime - startTime;
+  return (
+    durationMs >= 4 * 60 * 60 * 1000 &&
+    durationMs <= 6 * 60 * 60 * 1000
+  );
+}
+
+function pickTokenPlanModel(
+  modelRemains: unknown[],
+): Record<string, unknown> | undefined {
+  const models = modelRemains
+    .filter(isRecord)
+    .filter((model) => !isUnavailableQuotaModel(model));
+  return (
+    models.find((model) => isCodingQuotaModel(model) && hasQuotaWindow(model)) ??
+    models.find((model) => hasFiveHourWindow(model) && hasQuotaWindow(model)) ??
+    models.find(hasQuotaWindow)
+  );
+}
+
+interface MiniMaxWindowDefinition {
+  id: string;
+  label: string;
+  period: 'custom' | 'week';
+  totalKey: string;
+  remainingKey: string;
+  remainingPercentKey: string;
+  endTimeKey: string;
+  statusKey: string;
+}
+
+function parseTokenPlanWindow(
+  model: Record<string, unknown>,
+  definition: MiniMaxWindowDefinition,
+): BalanceMetric[] {
+  const items: BalanceMetric[] = [];
+  const total = pickNumberLike(model, definition.totalKey);
+  const rawRemaining = pickNumberLike(model, definition.remainingKey);
+  const rawRemainingPercent = pickNumberLike(
+    model,
+    definition.remainingPercentKey,
+  );
+  const endTime = pickNumberLike(model, definition.endTimeKey);
+  const status = pickNumberLike(model, definition.statusKey);
+  const hasCountQuota = total !== undefined && total > 0;
+  const remaining =
+    hasCountQuota && rawRemaining !== undefined
+      ? Math.max(0, Math.min(total, rawRemaining))
+      : undefined;
+  const remainingPercent = isValidPercent(rawRemainingPercent)
+    ? rawRemainingPercent
+    : remaining !== undefined && total !== undefined
+      ? (remaining / total) * 100
+      : undefined;
+  const metricContext = {
+    period: definition.period,
+    label: definition.label,
+  } as const;
+
+  if (remaining !== undefined && total !== undefined) {
+    items.push(
+      {
+        id: `${definition.id}-remaining`,
+        type: 'integer',
+        ...metricContext,
+        direction: 'remaining',
+        value: remaining,
+      },
+      {
+        id: `${definition.id}-used`,
+        type: 'integer',
+        ...metricContext,
+        direction: 'used',
+        value: Math.max(0, total - remaining),
+      },
+      {
+        id: `${definition.id}-limit`,
+        type: 'integer',
+        ...metricContext,
+        direction: 'limit',
+        value: total,
+      },
+    );
+  }
+
+  if (status === 3 && !hasCountQuota) {
+    items.push({
+      id: `${definition.id}-status`,
+      type: 'status',
+      ...metricContext,
+      value: 'unlimited',
+    });
+  } else if (remainingPercent !== undefined) {
+    items.push({
+      id: `${definition.id}-remaining-percent`,
+      type: 'percent',
+      ...metricContext,
+      value: remainingPercent,
+      basis: 'remaining',
+    });
+  } else if (status === 2) {
+    items.push({
+      id: `${definition.id}-status`,
+      type: 'status',
+      ...metricContext,
+      value: 'exhausted',
+    });
+  }
+
+  if (items.length > 0 && isValidTimestamp(endTime)) {
+    items.push({
+      id: `${definition.id}-reset`,
+      type: 'time',
+      ...metricContext,
+      kind: 'resetAt',
+      value: new Date(endTime).toISOString(),
+      timestampMs: endTime,
+    });
+  }
+
+  return items;
+}
+
+export function parseMiniMaxTokenPlanSnapshot(
+  value: unknown,
+  updatedAt = Date.now(),
+): BalanceSnapshot | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const modelRemains = value['model_remains'];
+  if (!Array.isArray(modelRemains) || modelRemains.length === 0) {
+    return undefined;
+  }
+  const model = pickTokenPlanModel(modelRemains);
+  if (!model) {
+    return undefined;
+  }
+
+  const intervalItems = parseTokenPlanWindow(model, {
+    id: 'minimax-token-plan-5-hour',
+    label: t('5-hour limit'),
+    period: 'custom',
+    totalKey: 'current_interval_total_count',
+    remainingKey: 'current_interval_usage_count',
+    remainingPercentKey: 'current_interval_remaining_percent',
+    endTimeKey: 'end_time',
+    statusKey: 'current_interval_status',
+  });
+  const weeklyItems = parseTokenPlanWindow(model, {
+    id: 'minimax-token-plan-weekly',
+    label: t('Weekly limit'),
+    period: 'week',
+    totalKey: 'current_weekly_total_count',
+    remainingKey: 'current_weekly_usage_count',
+    remainingPercentKey: 'current_weekly_remaining_percent',
+    endTimeKey: 'weekly_end_time',
+    statusKey: 'current_weekly_status',
+  });
+  const items = [...intervalItems, ...weeklyItems];
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  const primaryId =
+    intervalItems.find((item) => item.type === 'percent')?.id ??
+    intervalItems.find(
+      (item) => item.type === 'integer' && item.direction === 'remaining',
+    )?.id ??
+    intervalItems[0]?.id ??
+    weeklyItems[0]?.id;
+
+  return {
+    updatedAt,
+    items: items.map((item) => ({
+      ...item,
+      primary: item.id === primaryId,
+    })),
+  };
+}
+
+export function parseMiniMaxCodingPlanSnapshot(
+  value: unknown,
+  updatedAt = Date.now(),
+): BalanceSnapshot | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const modelRemains = value['model_remains'];
+  if (!Array.isArray(modelRemains) || modelRemains.length === 0) {
+    return undefined;
+  }
+  const firstModel = modelRemains[0];
+  if (!isRecord(firstModel)) {
+    return undefined;
+  }
+
+  const totalCount = pickNumberLike(
+    firstModel,
+    'current_interval_total_count',
+  );
+  const currentIntervalRemainingCount = pickNumberLike(
+    firstModel,
+    'current_interval_usage_count',
+  );
+  const endTime = pickNumberLike(firstModel, 'end_time');
+  if (
+    totalCount === undefined ||
+    currentIntervalRemainingCount === undefined ||
+    endTime === undefined
+  ) {
+    return undefined;
+  }
+
+  const usedCount = Math.max(0, totalCount - currentIntervalRemainingCount);
+  const usedPercent =
+    totalCount > 0
+      ? Math.max(0, Math.min(100, (usedCount / totalCount) * 100))
+      : 0;
+
+  return {
+    updatedAt,
+    items: [
+      {
+        id: 'minimax-requests',
+        type: 'integer',
+        period: 'current',
+        direction: 'used',
+        value: usedCount,
+        primary: true,
+      },
+      {
+        id: 'minimax-requests-limit',
+        type: 'integer',
+        period: 'current',
+        direction: 'limit',
+        value: totalCount,
+      },
+      {
+        id: 'minimax-used-percent',
+        type: 'percent',
+        period: 'current',
+        value: usedPercent,
+        basis: 'used',
+      },
+      {
+        id: 'minimax-period-end',
+        type: 'time',
+        period: 'current',
+        kind: 'resetAt',
+        value: new Date(endTime).toISOString(),
+        timestampMs: endTime,
+      },
+    ],
+  };
 }
 
 export class MiniMaxBalanceProvider implements BalanceProvider {
@@ -121,7 +444,7 @@ export class MiniMaxBalanceProvider implements BalanceProvider {
     return {
       id: 'minimax',
       label: t('MiniMax Balance'),
-      description: t('Monitor balance via MiniMax coding plan API'),
+      description: t('Monitor MiniMax Token Plan and Coding Plan quotas'),
     };
   }
 
@@ -162,141 +485,85 @@ export class MiniMaxBalanceProvider implements BalanceProvider {
       providerType: input.provider.type,
     });
 
-    try {
-      const balanceEndpoint = resolveMiniMaxBalanceEndpoint(input.provider.baseUrl);
-      const response = await fetchWithRetry(balanceEndpoint, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          Accept: 'application/json',
-        },
-        logger,
-        proxy: input.provider.proxy,
-      });
+    const queryEndpoint = async (
+      endpoint: string,
+      parseSnapshot: (value: unknown) => BalanceSnapshot | undefined,
+    ): Promise<BalanceRefreshResult> => {
+      try {
+        const response = await fetchWithRetry(endpoint, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            Accept: 'application/json',
+          },
+          logger,
+          proxy: input.provider.proxy,
+        });
 
-      if (!response.ok) {
-        const text = await response.text().catch(() => '');
-        return {
-          success: false,
-          error:
-            parseErrorMessage(text) ||
-            t(
-              'Failed to query {0} balance (HTTP {1}).',
-              'MiniMax',
-              `${response.status}`,
-            ),
-        };
-      }
-
-      const json: unknown = await response.json().catch(() => undefined);
-      if (!isRecord(json)) {
-        return {
-          success: false,
-          error: t('Unexpected {0} balance response.', 'MiniMax'),
-        };
-      }
-
-      const baseResp = json['base_resp'];
-      if (isRecord(baseResp)) {
-        const statusCode = pickNumberLike(baseResp, 'status_code');
-        if (statusCode !== undefined && statusCode !== 0) {
-          const statusMsg = pickString(baseResp, 'status_msg')?.trim();
+        if (!response.ok) {
+          const text = await response.text().catch(() => '');
           return {
             success: false,
-            error: statusMsg || t('Unexpected {0} balance response.', 'MiniMax'),
+            error:
+              parseErrorMessage(text) ||
+              t(
+                'Failed to query {0} balance (HTTP {1}).',
+                'MiniMax',
+                `${response.status}`,
+              ),
           };
         }
-      }
 
-      const modelRemains = json['model_remains'];
-      if (!Array.isArray(modelRemains) || modelRemains.length === 0) {
+        const json: unknown = await response.json().catch(() => undefined);
+        if (!isRecord(json)) {
+          return {
+            success: false,
+            error: t('Unexpected {0} balance response.', 'MiniMax'),
+          };
+        }
+
+        const baseResp = json['base_resp'];
+        if (isRecord(baseResp)) {
+          const statusCode = pickNumberLike(baseResp, 'status_code');
+          if (statusCode !== undefined && statusCode !== 0) {
+            const statusMsg = pickString(baseResp, 'status_msg')?.trim();
+            return {
+              success: false,
+              error:
+                statusMsg || t('Unexpected {0} balance response.', 'MiniMax'),
+            };
+          }
+        }
+
+        const snapshot = parseSnapshot(json);
+        if (!snapshot) {
+          return {
+            success: false,
+            error: t('Unexpected {0} balance response.', 'MiniMax'),
+          };
+        }
+
+        return { success: true, snapshot };
+      } catch (error) {
         return {
           success: false,
-          error: t('Unexpected {0} balance response.', 'MiniMax'),
+          error: error instanceof Error ? error.message : String(error),
         };
       }
+    };
 
-      // Use the first entry since all models have the same interval data.
-      const firstModel = modelRemains[0];
-      if (!isRecord(firstModel)) {
-        return {
-          success: false,
-          error: t('Unexpected {0} balance response.', 'MiniMax'),
-        };
-      }
-
-      const totalCount = pickNumberLike(
-        firstModel,
-        'current_interval_total_count',
-      );
-      const currentIntervalUsageCount = pickNumberLike(
-        firstModel,
-        'current_interval_usage_count',
-      );
-      const endTime = pickNumberLike(firstModel, 'end_time');
-      if (
-        totalCount === undefined ||
-        currentIntervalUsageCount === undefined ||
-        endTime === undefined
-      ) {
-        return {
-          success: false,
-          error: t('Unexpected {0} balance response.', 'MiniMax'),
-        };
-      }
-
-      // MiniMax's current_interval_usage_count is remaining quota for the current interval.
-      const usedCount = Math.max(0, totalCount - currentIntervalUsageCount);
-
-      const usedPercent = totalCount > 0
-        ? Math.max(0, Math.min(100, (usedCount / totalCount) * 100))
-        : 0;
-
-      const snapshot: BalanceSnapshot = {
-        updatedAt: Date.now(),
-        items: [
-          {
-            id: 'minimax-requests',
-            type: 'integer',
-            period: 'current',
-            direction: 'used',
-            value: usedCount,
-            primary: true,
-          },
-          {
-            id: 'minimax-requests-limit',
-            type: 'integer',
-            period: 'current',
-            direction: 'limit',
-            value: totalCount,
-          },
-          {
-            id: 'minimax-used-percent',
-            type: 'percent',
-            period: 'current',
-            value: usedPercent,
-            basis: 'used',
-          },
-          {
-            id: 'minimax-period-end',
-            type: 'time',
-            period: 'current',
-            kind: 'resetAt',
-            value: new Date(endTime).toISOString(),
-            timestampMs: endTime,
-          },
-        ],
-      };
-
-      return {
-        success: true,
-        snapshot,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
+    const tokenPlanResult = await queryEndpoint(
+      resolveMiniMaxTokenPlanEndpoint(input.provider.baseUrl),
+      parseMiniMaxTokenPlanSnapshot,
+    );
+    if (tokenPlanResult.success) {
+      return tokenPlanResult;
     }
+
+    const codingPlanResult = await queryEndpoint(
+      resolveMiniMaxCodingPlanEndpoint(input.provider.baseUrl),
+      parseMiniMaxCodingPlanSnapshot,
+    );
+    return codingPlanResult.success ? codingPlanResult : tokenPlanResult;
   }
 }

--- a/src/balance/types.ts
+++ b/src/balance/types.ts
@@ -162,6 +162,8 @@ export interface BalancePercentMetric extends BalanceMetricBase {
   type: 'percent';
   value: number;
   basis?: 'remaining' | 'used';
+  /** Optional formatting ceiling for provider percentages that can exceed 100. */
+  displayMaximum?: number;
 }
 
 export interface BalanceTimeMetric extends BalanceMetricBase {

--- a/test/unit/minimax-balance-provider.test.ts
+++ b/test/unit/minimax-balance-provider.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import type { BalanceProviderContext } from '../../src/balance/balance-provider';
+import type { ProviderConfig } from '../../src/types';
+
+const mocks = vi.hoisted(() => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+vi.mock('vscode', () => {
+  class EventEmitter<T> {
+    readonly event = (_listener: (value: T) => void) => ({
+      dispose: () => undefined,
+    });
+    fire(_value: T): void {}
+    dispose(): void {}
+  }
+
+  return {
+    EventEmitter,
+    env: { language: 'en' },
+    l10n: { t: (message: string) => message },
+  };
+});
+
+vi.mock('../../src/client/utils', () => ({
+  getToken: (credential: { kind?: string; token?: string } | undefined) =>
+    credential?.kind === 'token' ? credential.token : undefined,
+}));
+
+vi.mock('../../src/logger', () => ({
+  authLog: { warn: vi.fn() },
+  createSimpleHttpLogger: () => ({
+    logRequest: vi.fn(),
+    logResponse: vi.fn(),
+    logError: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/utils', () => ({
+  fetchWithRetry: mocks.fetchWithRetry,
+}));
+
+import {
+  MiniMaxBalanceProvider,
+  parseMiniMaxCodingPlanSnapshot,
+  parseMiniMaxTokenPlanSnapshot,
+  resolveMiniMaxCodingPlanEndpoint,
+  resolveMiniMaxTokenPlanEndpoint,
+} from '../../src/balance/providers/minimax';
+import { SecretStore } from '../../src/secret/secret-store';
+
+function createSecretStore(): SecretStore {
+  const storage: vscode.SecretStorage = {
+    onDidChange: () => ({ dispose: () => undefined }),
+    keys: async () => [],
+    get: async () => undefined,
+    store: async () => undefined,
+    delete: async () => undefined,
+  };
+  return new SecretStore(storage);
+}
+
+function createBalanceProvider(): MiniMaxBalanceProvider {
+  const context: BalanceProviderContext = {
+    providerId: 'minimax',
+    providerLabel: 'MiniMax',
+    secretStore: createSecretStore(),
+  };
+  return new MiniMaxBalanceProvider(context, { method: 'minimax' });
+}
+
+function providerConfig(baseUrl: string): ProviderConfig {
+  return {
+    type: 'anthropic',
+    name: 'MiniMax',
+    baseUrl,
+    models: [],
+  };
+}
+
+describe('MiniMax balance provider', () => {
+  beforeEach(() => {
+    mocks.fetchWithRetry.mockReset();
+  });
+
+  it('resolves the current Token Plan endpoint for each MiniMax region', () => {
+    expect(
+      resolveMiniMaxTokenPlanEndpoint('https://api.minimax.io/anthropic'),
+    ).toBe('https://www.minimax.io/v1/token_plan/remains');
+    expect(
+      resolveMiniMaxTokenPlanEndpoint('https://api.minimaxi.com/anthropic'),
+    ).toBe('https://www.minimaxi.com/v1/token_plan/remains');
+    expect(
+      resolveMiniMaxCodingPlanEndpoint('https://api.minimax.io/anthropic'),
+    ).toBe(
+      'https://api.minimax.io/v1/api/openplatform/coding_plan/remains',
+    );
+  });
+
+  it('parses the coding model 5-hour and weekly Token Plan windows', () => {
+    const intervalEnd = 1_800_000_000_000;
+    const weeklyEnd = intervalEnd + 5 * 24 * 60 * 60 * 1000;
+    const snapshot = parseMiniMaxTokenPlanSnapshot(
+      {
+        model_remains: [
+          {
+            model_name: 'image-01',
+            current_interval_total_count: 100,
+            current_interval_usage_count: 1,
+            current_interval_remaining_percent: 1,
+          },
+          {
+            model_name: 'MiniMax-M3',
+            start_time: intervalEnd - 5 * 60 * 60 * 1000,
+            end_time: intervalEnd,
+            current_interval_total_count: 1_500,
+            current_interval_usage_count: 1_200,
+            current_interval_remaining_percent: 80,
+            current_interval_status: 1,
+            current_weekly_total_count: 15_000,
+            current_weekly_usage_count: 13_500,
+            current_weekly_remaining_percent: 90,
+            current_weekly_status: 1,
+            weekly_end_time: weeklyEnd,
+          },
+        ],
+      },
+      123,
+    );
+
+    expect(snapshot).toMatchObject({ updatedAt: 123 });
+    expect(snapshot?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'minimax-token-plan-5-hour-remaining',
+          direction: 'remaining',
+          value: 1_200,
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-5-hour-used',
+          direction: 'used',
+          value: 300,
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-5-hour-remaining-percent',
+          value: 80,
+          basis: 'remaining',
+          primary: true,
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-used',
+          direction: 'used',
+          value: 1_500,
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-remaining-percent',
+          value: 90,
+          basis: 'remaining',
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-reset',
+          timestampMs: weeklyEnd,
+        }),
+      ]),
+    );
+  });
+
+  it('uses percent-only Token Plan windows when count quotas are zero', () => {
+    const snapshot = parseMiniMaxTokenPlanSnapshot({
+      model_remains: [
+        {
+          model_name: 'general',
+          current_interval_total_count: 0,
+          current_interval_usage_count: 0,
+          current_interval_remaining_percent: 42,
+          current_interval_status: 1,
+          end_time: 1_800_000_000_000,
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          current_weekly_remaining_percent: 73,
+          current_weekly_status: 1,
+          weekly_end_time: 1_800_500_000_000,
+        },
+      ],
+    });
+
+    expect(snapshot?.items.some((item) => item.type === 'integer')).toBe(false);
+    expect(snapshot?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'minimax-token-plan-5-hour-remaining-percent',
+          value: 42,
+        }),
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-remaining-percent',
+          value: 73,
+        }),
+      ]),
+    );
+  });
+
+  it('rejects Token Plan rows that the API marks as unavailable', () => {
+    expect(
+      parseMiniMaxTokenPlanSnapshot({
+        model_remains: [
+          {
+            model_name: 'general',
+            current_interval_total_count: 0,
+            current_weekly_total_count: 0,
+            current_interval_remaining_percent: 100,
+            current_weekly_remaining_percent: 100,
+            current_interval_status: 3,
+            current_weekly_status: 3,
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('preserves legacy Coding Plan count semantics', () => {
+    const snapshot = parseMiniMaxCodingPlanSnapshot({
+      model_remains: [
+        {
+          current_interval_total_count: 1_000,
+          current_interval_usage_count: 750,
+          end_time: 1_800_000_000_000,
+        },
+      ],
+    });
+
+    expect(snapshot?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'minimax-requests',
+          direction: 'used',
+          value: 250,
+          primary: true,
+        }),
+      ]),
+    );
+  });
+
+  it('uses the Token Plan endpoint without querying the legacy endpoint', async () => {
+    mocks.fetchWithRetry.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          base_resp: { status_code: 0 },
+          model_remains: [
+            {
+              model_name: 'MiniMax-M3',
+              current_interval_total_count: 1_500,
+              current_interval_usage_count: 1_200,
+              current_interval_remaining_percent: 80,
+              end_time: 1_800_000_000_000,
+              current_weekly_total_count: 15_000,
+              current_weekly_usage_count: 13_500,
+              current_weekly_remaining_percent: 90,
+              weekly_end_time: 1_800_500_000_000,
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await createBalanceProvider().refresh({
+      provider: providerConfig('https://api.minimax.io/anthropic'),
+      credential: { kind: 'token', token: 'token-plan-key' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.fetchWithRetry).toHaveBeenCalledOnce();
+    expect(mocks.fetchWithRetry).toHaveBeenCalledWith(
+      'https://www.minimax.io/v1/token_plan/remains',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-plan-key',
+        }),
+      }),
+    );
+  });
+
+  it('falls back to the legacy Coding Plan endpoint', async () => {
+    mocks.fetchWithRetry
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'not a Token Plan key' }), {
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            base_resp: { status_code: 0 },
+            model_remains: [
+              {
+                current_interval_total_count: 1_000,
+                current_interval_usage_count: 900,
+                end_time: 1_800_000_000_000,
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+    const result = await createBalanceProvider().refresh({
+      provider: providerConfig('https://api.minimax.io/anthropic'),
+      credential: { kind: 'token', token: 'legacy-key' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.fetchWithRetry).toHaveBeenCalledTimes(2);
+    expect(mocks.fetchWithRetry.mock.calls.map(([url]) => url)).toEqual([
+      'https://www.minimax.io/v1/token_plan/remains',
+      'https://api.minimax.io/v1/api/openplatform/coding_plan/remains',
+    ]);
+  });
+});

--- a/test/unit/minimax-balance-provider.test.ts
+++ b/test/unit/minimax-balance-provider.test.ts
@@ -48,6 +48,10 @@ import {
   resolveMiniMaxCodingPlanEndpoint,
   resolveMiniMaxTokenPlanEndpoint,
 } from '../../src/balance/providers/minimax';
+import {
+  formatMetricValue,
+  formatSnapshotLines,
+} from '../../src/balance/display';
 import { SecretStore } from '../../src/secret/secret-store';
 
 function createSecretStore(): SecretStore {
@@ -91,6 +95,11 @@ describe('MiniMax balance provider', () => {
     expect(
       resolveMiniMaxTokenPlanEndpoint('https://api.minimaxi.com/anthropic'),
     ).toBe('https://www.minimaxi.com/v1/token_plan/remains');
+    expect(
+      resolveMiniMaxTokenPlanEndpoint(
+        'https://gateway.example.test/minimax/anthropic',
+      ),
+    ).toBe('https://gateway.example.test/v1/token_plan/remains');
     expect(
       resolveMiniMaxCodingPlanEndpoint('https://api.minimax.io/anthropic'),
     ).toBe(
@@ -178,8 +187,9 @@ describe('MiniMax balance provider', () => {
           end_time: 1_800_000_000_000,
           current_weekly_total_count: 0,
           current_weekly_usage_count: 0,
-          current_weekly_remaining_percent: 73,
+          current_weekly_remaining_percent: 100,
           current_weekly_status: 1,
+          weekly_boost_permille: 1500,
           weekly_end_time: 1_800_500_000_000,
         },
       ],
@@ -194,10 +204,96 @@ describe('MiniMax balance provider', () => {
         }),
         expect.objectContaining({
           id: 'minimax-token-plan-weekly-remaining-percent',
-          value: 73,
+          value: 150,
+          displayMaximum: 200,
         }),
       ]),
     );
+    const weeklyPercent = snapshot?.items.find(
+      (item) =>
+        item.id === 'minimax-token-plan-weekly-remaining-percent' &&
+        item.type === 'percent',
+    );
+    expect(weeklyPercent && formatMetricValue(weeklyPercent)).toBe('150%');
+    expect(
+      formatSnapshotLines(snapshot).some((line) =>
+        line.includes('150% remaining'),
+      ),
+    ).toBe(true);
+  });
+
+  it('caps boosted weekly percentages at the 200% display ceiling', () => {
+    const snapshot = parseMiniMaxTokenPlanSnapshot({
+      model_remains: [
+        {
+          model_name: 'general',
+          current_interval_total_count: 0,
+          current_interval_usage_count: 0,
+          current_interval_remaining_percent: 50,
+          current_interval_status: 1,
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          current_weekly_remaining_percent: 100,
+          current_weekly_status: 1,
+          weekly_boost_permille: 5000,
+        },
+      ],
+    });
+
+    expect(snapshot?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-remaining-percent',
+          type: 'percent',
+          value: 200,
+          displayMaximum: 200,
+        }),
+      ]),
+    );
+    expect(
+      formatSnapshotLines(snapshot).some((line) =>
+        line.includes('200% remaining'),
+      ),
+    ).toBe(true);
+  });
+
+  it('prioritizes an unlimited weekly status over counts and boost', () => {
+    const snapshot = parseMiniMaxTokenPlanSnapshot({
+      model_remains: [
+        {
+          model_name: 'general',
+          current_interval_total_count: 100,
+          current_interval_usage_count: 50,
+          current_interval_remaining_percent: 50,
+          current_interval_status: 1,
+          current_weekly_total_count: 1_000,
+          current_weekly_usage_count: 900,
+          current_weekly_remaining_percent: 90,
+          current_weekly_status: 3,
+          weekly_boost_permille: 1500,
+        },
+      ],
+    });
+
+    expect(snapshot?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'minimax-token-plan-weekly-status',
+          type: 'status',
+          value: 'unlimited',
+        }),
+      ]),
+    );
+    expect(
+      snapshot?.items.some(
+        (item) =>
+          item.id.startsWith('minimax-token-plan-weekly-') &&
+          (item.type === 'integer' || item.type === 'percent'),
+      ),
+    ).toBe(false);
+    const lines = formatSnapshotLines(snapshot);
+    expect(lines.some((line) => line.includes('Unlimited'))).toBe(true);
+    expect(lines.some((line) => line.includes('135% remaining'))).toBe(false);
   });
 
   it('rejects Token Plan rows that the API marks as unavailable', () => {
@@ -282,7 +378,7 @@ describe('MiniMax balance provider', () => {
     );
   });
 
-  it('falls back to the legacy Coding Plan endpoint', async () => {
+  it('keeps credentials on a custom provider origin while falling back', async () => {
     mocks.fetchWithRetry
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ message: 'not a Token Plan key' }), {
@@ -306,15 +402,35 @@ describe('MiniMax balance provider', () => {
       );
 
     const result = await createBalanceProvider().refresh({
-      provider: providerConfig('https://api.minimax.io/anthropic'),
+      provider: providerConfig(
+        'https://gateway.example.test/minimax/anthropic',
+      ),
       credential: { kind: 'token', token: 'legacy-key' },
     });
 
     expect(result.success).toBe(true);
     expect(mocks.fetchWithRetry).toHaveBeenCalledTimes(2);
     expect(mocks.fetchWithRetry.mock.calls.map(([url]) => url)).toEqual([
-      'https://www.minimax.io/v1/token_plan/remains',
-      'https://api.minimax.io/v1/api/openplatform/coding_plan/remains',
+      'https://gateway.example.test/v1/token_plan/remains',
+      'https://gateway.example.test/v1/api/openplatform/coding_plan/remains',
     ]);
+    expect(mocks.fetchWithRetry).toHaveBeenNthCalledWith(
+      1,
+      'https://gateway.example.test/v1/token_plan/remains',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer legacy-key',
+        }),
+      }),
+    );
+    expect(mocks.fetchWithRetry).toHaveBeenNthCalledWith(
+      2,
+      'https://gateway.example.test/v1/api/openplatform/coding_plan/remains',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer legacy-key',
+        }),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- query the current MiniMax Token Plan remains endpoint for international and China providers
- keep custom provider endpoints and Authorization credentials on their configured origin
- expose 5-hour and weekly remaining/used quota, percentages, and reset timestamps
- apply `weekly_boost_permille`, display boosted weekly quota up to the explicit 200% ceiling, and prioritize unlimited status
- retain the same-origin legacy Coding Plan endpoint as an automatic fallback
- reject unavailable 0/0 model buckets and prefer the coding/text quota model

## Tests
- `npx vitest run test/unit/minimax-balance-provider.test.ts` (9 passed)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `npm run l10n:check`
- `npm run test:unit` (1240 passed, 1 unrelated pre-existing failure in `plan4-provider-catalog.test.ts`; reproduced on clean `main` at 616a3bd)

Fixes #294
