### PR TITLE
fix(antigravity): strip MCP header schema annotations

### DIFF
--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -451,7 +451,7 @@ function buildToolParameterSignature(schema: unknown): string {
   return segments.join(', ');
 }
 
-function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
+export function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
   const unsupportedConstraints = new Set<string>([
     'minLength',
     'maxLength',
@@ -480,6 +480,8 @@ function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
     'markdownDescription',
     'deprecationMessage',
     'errorMessage',
+    // MCP transport metadata is not a Google FunctionDeclaration schema field.
+    'x-mcp-header',
   ]);
 
   const appendHintToDescription = (

--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -480,9 +480,22 @@ export function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
     'markdownDescription',
     'deprecationMessage',
     'errorMessage',
-    // MCP transport metadata is not a Google FunctionDeclaration schema field.
-    'x-mcp-header',
   ]);
+
+  const cloneOpaqueValue = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(cloneOpaqueValue);
+    }
+    if (!isRecord(value)) {
+      return value;
+    }
+
+    const cloned: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      cloned[key] = cloneOpaqueValue(child);
+    }
+    return cloned;
+  };
 
   const appendHintToDescription = (
     target: Record<string, unknown>,
@@ -747,6 +760,10 @@ export function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
       if (droppedKeys.has(k)) {
         continue;
       }
+      if (k === 'x-mcp-header') {
+        // MCP transport metadata is not a Google schema field.
+        continue;
+      }
 
       if (k === '$ref' || k === 'allOf' || k === 'anyOf' || k === 'oneOf') {
         continue;
@@ -754,8 +771,14 @@ export function cleanJsonSchemaForAntigravity(schema: unknown): unknown {
 
       if (k === 'const') {
         if (!Array.isArray(out['enum'])) {
-          out['enum'] = [clean(v, { topLevel: false }).value];
+          out['enum'] = [cloneOpaqueValue(v)];
         }
+        continue;
+      }
+
+      if (k === 'example' || k === 'enum') {
+        // Instance values are opaque data, not child schema nodes.
+        out[k] = cloneOpaqueValue(v);
         continue;
       }
 

--- a/test/unit/antigravity-schema.test.ts
+++ b/test/unit/antigravity-schema.test.ts
@@ -21,6 +21,7 @@ describe('Antigravity tool schema', () => {
     expect(
       cleanJsonSchemaForAntigravity({
         type: 'object',
+        'x-mcp-header': 'Root',
         properties: {
           region: {
             type: 'string',
@@ -57,5 +58,63 @@ describe('Antigravity tool schema', () => {
       },
       required: ['region'],
     });
+  });
+
+  it('preserves x-mcp-header keys inside opaque schema values', () => {
+    const literal = { 'x-mcp-header': 'literal' };
+
+    expect(
+      cleanJsonSchemaForAntigravity({ example: literal }),
+    ).toEqual({ example: literal });
+    expect(cleanJsonSchemaForAntigravity({ const: literal })).toEqual({
+      enum: [JSON.stringify(literal)],
+    });
+    expect(cleanJsonSchemaForAntigravity({ enum: [literal] })).toEqual({
+      enum: [JSON.stringify(literal)],
+    });
+  });
+
+  it('keeps a tool argument named x-mcp-header and its required entry', () => {
+    expect(
+      cleanJsonSchemaForAntigravity({
+        type: 'object',
+        properties: {
+          'x-mcp-header': {
+            type: 'string',
+            description: 'A regular tool argument',
+          },
+        },
+        required: ['x-mcp-header'],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        'x-mcp-header': {
+          type: 'string',
+          description: 'A regular tool argument',
+        },
+      },
+      required: ['x-mcp-header'],
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        region: {
+          type: 'string',
+          'x-mcp-header': 'Region',
+          example: { 'x-mcp-header': 'literal' },
+        },
+      },
+      required: ['region'],
+    };
+    const original = structuredClone(schema);
+
+    const cleaned = cleanJsonSchemaForAntigravity(schema);
+
+    expect(schema).toEqual(original);
+    expect(cleaned).not.toBe(schema);
   });
 });

--- a/test/unit/antigravity-schema.test.ts
+++ b/test/unit/antigravity-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+}));
+
+vi.mock('../../src/client/utils', () => ({}));
+vi.mock('../../src/utils', () => ({}));
+vi.mock('../../src/client/google/ai-studio-client', () => ({
+  GoogleAIStudioProvider: class {},
+}));
+
+import { cleanJsonSchemaForAntigravity } from '../../src/client/google/code-assist-client';
+
+describe('Antigravity tool schema', () => {
+  it('removes MCP transport header annotations recursively', () => {
+    expect(
+      cleanJsonSchemaForAntigravity({
+        type: 'object',
+        properties: {
+          region: {
+            type: 'string',
+            description: 'The region to query',
+            'x-mcp-header': 'Region',
+          },
+          options: {
+            type: 'object',
+            properties: {
+              tenant: {
+                type: 'string',
+                'x-mcp-header': 'Tenant',
+              },
+            },
+          },
+        },
+        required: ['region'],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        region: {
+          type: 'string',
+          description: 'The region to query',
+        },
+        options: {
+          type: 'object',
+          properties: {
+            tenant: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      required: ['region'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- strip the MCP-only `x-mcp-header` annotation from Antigravity tool schemas before sending Google FunctionDeclarations
- preserve `example`, `const`, and `enum` instance data while sanitizing schema nodes
- add regression tests covering direct and nested annotations, opaque values, same-named tool arguments, and input immutability

## Root cause

MCP tool schemas can annotate input properties with `x-mcp-header` for transport-level header mirroring. Antigravity's schema cleaner recursively copied unknown keys unless they appeared in its explicit drop list, so the annotation reached Google's strict proto JSON parser. Google does not define `x-mcp-header` on FunctionDeclaration schemas and rejected the whole request with HTTP 400.

The sanitizer removes the annotation only while traversing schema nodes. Opaque instance values are deep-copied unchanged, and a real property named `x-mcp-header` remains available to the model and in `required`. The original MCP tool schema is not mutated.

## Validation

- `npx vitest run test/unit/antigravity-schema.test.ts` (4 tests passed)
- `npm run test:unit -- --exclude test/unit/plan4-provider-catalog.test.ts` (104 files, 1229 tests passed, including TypeScript and release checks)
- `npm test` reached Vitest after all TypeScript and release checks; 1235 of 1236 tests passed. The sole failure is an unrelated current-`main` baseline in `plan4-provider-catalog.test.ts`: the newly added DeepSeek V4 Flash Vision Exp model has no FIM completion template. This branch does not modify that test or the model catalog.

Fixes #290
