### PR TITLE
fix(codex): enable GPT-5.6 1M context

### DIFF
--- a/src/client/openai/codex-client.ts
+++ b/src/client/openai/codex-client.ts
@@ -47,6 +47,9 @@ const CODEX_REASONING_SUMMARY_DEFAULTS = {
     summary: 'auto',
   },
 } satisfies Pick<ModelConfig, 'maxOutputTokens' | 'thinking'>;
+// Codex's 1M long-context mode reserves 128K tokens for model output.
+const CODEX_GPT_5_6_MAX_INPUT_TOKENS = 872000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -449,17 +452,17 @@ export class OpenAICodexProvider extends OpenAIResponsesProvider {
     return [
       {
         id: 'gpt-5.6-sol',
-        maxInputTokens: 272000,
+        maxInputTokens: CODEX_GPT_5_6_MAX_INPUT_TOKENS,
         ...CODEX_REASONING_SUMMARY_DEFAULTS,
       },
       {
         id: 'gpt-5.6-terra',
-        maxInputTokens: 272000,
+        maxInputTokens: CODEX_GPT_5_6_MAX_INPUT_TOKENS,
         ...CODEX_REASONING_SUMMARY_DEFAULTS,
       },
       {
         id: 'gpt-5.6-luna',
-        maxInputTokens: 272000,
+        maxInputTokens: CODEX_GPT_5_6_MAX_INPUT_TOKENS,
         ...CODEX_REASONING_SUMMARY_DEFAULTS,
       },
       {

--- a/test/unit/openai-codex-models.test.ts
+++ b/test/unit/openai-codex-models.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+  LanguageModelChatMessageRole: { User: 1, Assistant: 2, System: 3 },
+  LanguageModelToolMode: { Auto: 1, Required: 2 },
+  window: {
+    createOutputChannel: () => ({
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    }),
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key: string, fallback: unknown) => fallback,
+    }),
+  },
+}));
+
+vi.mock('../../src/client/definitions', () => ({ FeatureId: {} }));
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => undefined,
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  buildBaseUrl: (baseUrl: string) => baseUrl,
+  createCustomFetch: vi.fn(),
+  getToken: () => undefined,
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+}));
+
+vi.mock('../../src/utils', () => ({
+  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
+    connection: 60000,
+    response: 300000,
+  },
+  FetchMode: { Normal: 'normal' },
+  isRawBaseUrlEnabled: () => false,
+}));
+
+import { OpenAICodexProvider } from '../../src/client/openai/codex-client';
+import type { ProviderConfig } from '../../src/types';
+import { mergeWithWellKnownModels } from '../../src/well-known/models';
+
+const providerConfig: ProviderConfig = {
+  type: 'openai-codex',
+  name: 'OpenAI Codex (ChatGPT Plus/Pro)',
+  baseUrl: 'https://chatgpt.com/backend-api/codex/responses',
+  models: [],
+  autoFetchOfficialModels: true,
+};
+
+describe('OpenAI Codex official models', () => {
+  it('reports the GPT-5.6 long-context input budget after catalog merging', async () => {
+    const provider = new OpenAICodexProvider(providerConfig);
+    const fetched = await provider.getAvailableModels({ kind: 'none' });
+    const models = mergeWithWellKnownModels(fetched, providerConfig);
+    const modelsById = new Map(models.map((model) => [model.id, model]));
+
+    for (const modelId of [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ]) {
+      expect(modelsById.get(modelId)?.maxInputTokens).toBe(872000);
+    }
+
+    expect(modelsById.get('gpt-5.5')?.maxInputTokens).toBe(272000);
+  });
+});


### PR DESCRIPTION
## Summary
- update auto-fetched GPT-5.6 Sol, Terra, and Luna to the 872,000-token input budget used by Codex's 1M long-context mode
- preserve the 128,000-token output reserve and the existing GPT-5.5 budget
- add a regression test for the final merged official-model metadata

## Rationale
OpenAI Codex raised the GPT-5.6 maximum context override to 872,000 input tokens for a 1,000,000-token total context, reserving 128,000 tokens for output:

https://github.com/openai/codex/pull/39102

The provider's hardcoded 272,000 values take precedence over the well-known model catalog, so auto-fetched read-only GPT-5.6 models remained at 272K even though a manually added model could use the larger budget.

## Validation
- npm exec vitest run test/unit/openai-codex-models.test.ts test/unit/official-models-manager.test.ts (5 passed)
- npm run test:unit (TypeScript, release, resource, and build checks passed; 104 test files and 1,232 tests passed)
- the one remaining suite failure is pre-existing: clean main at 616a3bd reproduces the same DeepSeek FIM assertion in test/unit/plan4-provider-catalog.test.ts

Fixes #297
