### PR TITLE
fix(openai): preserve DeepSeek V4 reasoning history

### DIFF
--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -795,7 +795,10 @@ export const FEATURES: Record<FeatureId, Feature> = {
       'qianfan.baidubce.com',
       'integrate.api.nvidia.com',
     ],
-    customCheckers: [isQwen38ModelStudioEndpoint],
+    customCheckers: [
+      isQwen38ModelStudioEndpoint,
+      (model) => modelFamilyIncludes(model, 'deepseek-v4'),
+    ],
   },
   [FeatureId.OpenAIUseClearThinking]: {
     supportedProviders: ['open.bigmodel.cn', 'api.z.ai'],

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -340,11 +340,74 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
               }
             }
 
+            const convertedMessage: ChatCompletionAssistantMessageParam = {
+              role: 'assistant',
+            };
             for (const part of msg.content) {
-              const parts = this.convertPart(msg.role, part, reasoningType) as
+              const convertedPart = this.convertPart(
+                msg.role,
+                part,
+                reasoningType,
+              ) as
                 | ChatCompletionAssistantMessageParam
                 | undefined;
-              if (parts) outMessages.push(parts);
+              if (!convertedPart) continue;
+
+              const incomingContent = convertedPart.content;
+              if (incomingContent !== undefined && incomingContent !== null) {
+                const currentContent = convertedMessage.content;
+                if (currentContent === undefined || currentContent === null) {
+                  convertedMessage.content = incomingContent;
+                } else if (typeof currentContent === 'string') {
+                  convertedMessage.content =
+                    typeof incomingContent === 'string'
+                      ? currentContent + incomingContent
+                      : [
+                          { type: 'text', text: currentContent },
+                          ...incomingContent,
+                        ];
+                } else {
+                  convertedMessage.content =
+                    typeof incomingContent === 'string'
+                      ? [
+                          ...currentContent,
+                          { type: 'text', text: incomingContent },
+                        ]
+                      : [...currentContent, ...incomingContent];
+                }
+              }
+
+              if (convertedPart.reasoning_content !== undefined) {
+                convertedMessage.reasoning_content =
+                  (convertedMessage.reasoning_content ?? '') +
+                  convertedPart.reasoning_content;
+              }
+              if (convertedPart.reasoning !== undefined) {
+                convertedMessage.reasoning =
+                  (convertedMessage.reasoning ?? '') + convertedPart.reasoning;
+              }
+              if (convertedPart.reasoning_details !== undefined) {
+                convertedMessage.reasoning_details = [
+                  ...(convertedMessage.reasoning_details ?? []),
+                  ...convertedPart.reasoning_details,
+                ];
+              }
+              if (convertedPart.tool_calls !== undefined) {
+                convertedMessage.tool_calls = [
+                  ...(convertedMessage.tool_calls ?? []),
+                  ...convertedPart.tool_calls,
+                ];
+              }
+            }
+
+            if (
+              convertedMessage.content !== undefined ||
+              convertedMessage.reasoning_content !== undefined ||
+              convertedMessage.reasoning !== undefined ||
+              convertedMessage.reasoning_details !== undefined ||
+              convertedMessage.tool_calls !== undefined
+            ) {
+              outMessages.push(convertedMessage);
             }
           }
           break;
@@ -359,8 +422,6 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       const index = outMessages.indexOf(param);
       outMessages[index] = raw;
     }
-
-    // TODO 将连续的不同种类的 Assistant 消息尽量合并为一条消息（比如 content, reasoning_content, tool_calls 可以合并，但是 content, content 则不可以合并，(content and reasoning_content), tool_calls 可以合并）
 
     // add a cache breakpoint at the end.
     if (shouldApplyCacheControl) {

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -387,14 +387,9 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
                   (convertedMessage.reasoning ?? '') + convertedPart.reasoning;
               }
               if (convertedPart.reasoning_details !== undefined) {
-                const currentDetails =
-                  convertedMessage.reasoning_details ?? [];
                 convertedMessage.reasoning_details = [
-                  ...currentDetails,
-                  ...convertedPart.reasoning_details.map((detail, index) => ({
-                    ...detail,
-                    index: currentDetails.length + index,
-                  })),
+                  ...(convertedMessage.reasoning_details ?? []),
+                  ...convertedPart.reasoning_details,
                 ];
               }
               if (convertedPart.tool_calls !== undefined) {
@@ -1185,7 +1180,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       expectedIdentity,
       imageRetention:
         model.capabilities?.imageInput === true ? 'user-only' : 'discard',
-      preserveThinkingToolRounds: reasoningType !== 'none',
+      preserveThinkingToolRounds: reasoningType === 'content',
     });
 
     const convertedMessages = this.convertMessages(

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -387,9 +387,14 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
                   (convertedMessage.reasoning ?? '') + convertedPart.reasoning;
               }
               if (convertedPart.reasoning_details !== undefined) {
+                const currentDetails =
+                  convertedMessage.reasoning_details ?? [];
                 convertedMessage.reasoning_details = [
-                  ...(convertedMessage.reasoning_details ?? []),
-                  ...convertedPart.reasoning_details,
+                  ...currentDetails,
+                  ...convertedPart.reasoning_details.map((detail, index) => ({
+                    ...detail,
+                    index: currentDetails.length + index,
+                  })),
                 ];
               }
               if (convertedPart.tool_calls !== undefined) {
@@ -1180,6 +1185,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       expectedIdentity,
       imageRetention:
         model.capabilities?.imageInput === true ? 'user-only' : 'discard',
+      preserveThinkingToolRounds: reasoningType !== 'none',
     });
 
     const convertedMessages = this.convertMessages(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2750,6 +2750,17 @@ export interface SanitizedMessagesForModelSwitchResult {
 
 export type SanitizedImagePartRetention = 'discard' | 'user-only' | 'all';
 
+export interface SanitizeMessagesForModelSwitchOptions {
+  modelId: string;
+  expectedIdentity: string;
+  imageRetention?: SanitizedImagePartRetention;
+  /**
+   * Preserve complete thinking + tool-call exchanges as portable fallback
+   * history when VS Code omits the provider's stateful marker.
+   */
+  preserveThinkingToolRounds?: boolean;
+}
+
 function collectExplicitToolCallIds(
   message: vscode.LanguageModelChatRequestMessage,
 ): string[] {
@@ -2775,6 +2786,60 @@ function collectExplicitToolResultIds(
       ? [part.callId]
       : [],
   );
+}
+
+function isThinkingToolCallMessage(
+  message: vscode.LanguageModelChatRequestMessage,
+): boolean {
+  const ThinkingPart: unknown = vscode.LanguageModelThinkingPart;
+  return (
+    message.role === vscode.LanguageModelChatMessageRole.Assistant &&
+    collectExplicitToolCallIds(message).length > 0 &&
+    typeof ThinkingPart === 'function' &&
+    message.content.some((part) => part instanceof ThinkingPart)
+  );
+}
+
+function sanitizeThinkingToolCallMessage(
+  message: vscode.LanguageModelChatRequestMessage,
+): vscode.LanguageModelChatRequestMessage | undefined {
+  if (!isThinkingToolCallMessage(message)) {
+    return undefined;
+  }
+
+  const ThinkingPart = vscode.LanguageModelThinkingPart;
+  const portableParts = message.content.filter(
+    (
+      part,
+    ): part is
+      | vscode.LanguageModelTextPart
+      | vscode.LanguageModelThinkingPart
+      | vscode.LanguageModelToolCallPart =>
+      part instanceof vscode.LanguageModelTextPart ||
+      part instanceof ThinkingPart ||
+      part instanceof vscode.LanguageModelToolCallPart,
+  );
+
+  return {
+    role: message.role,
+    name: message.name,
+    content: portableParts,
+  };
+}
+
+function markIncompleteThinkingToolExchanges(
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  fallbackMessageIndexes: ReadonlySet<number>,
+  sanitizedMessageIndexes: Set<number>,
+): void {
+  const resultIds = new Set(messages.flatMap(collectExplicitToolResultIds));
+
+  for (const index of fallbackMessageIndexes) {
+    const callIds = collectExplicitToolCallIds(messages[index]);
+    if (callIds.some((callId) => !resultIds.has(callId))) {
+      sanitizedMessageIndexes.add(index);
+    }
+  }
 }
 
 function sanitizeMessageForModelSwitch(
@@ -2879,13 +2944,10 @@ function propagateSanitizedToolNeighbors(
 
 export function sanitizeMessagesForModelSwitchDetailed(
   messages: readonly vscode.LanguageModelChatRequestMessage[],
-  options: {
-    modelId: string;
-    expectedIdentity: string;
-    imageRetention?: SanitizedImagePartRetention;
-  },
+  options: SanitizeMessagesForModelSwitchOptions,
 ): SanitizedMessagesForModelSwitchResult {
   const sanitizedMessageIndexes = new Set<number>();
+  const thinkingToolFallbackIndexes = new Set<number>();
 
   let round: number[] = [];
   let roundHasAssistant = false;
@@ -2928,7 +2990,15 @@ export function sanitizeMessagesForModelSwitchDetailed(
 
       if (!isRoundValid) {
         for (const index of round) {
-          sanitizedMessageIndexes.add(index);
+          const message = messages[index];
+          if (
+            options.preserveThinkingToolRounds &&
+            isThinkingToolCallMessage(message)
+          ) {
+            thinkingToolFallbackIndexes.add(index);
+          } else {
+            sanitizedMessageIndexes.add(index);
+          }
         }
       }
     }
@@ -2963,11 +3033,28 @@ export function sanitizeMessagesForModelSwitchDetailed(
 
   flush();
 
+  markIncompleteThinkingToolExchanges(
+    messages,
+    thinkingToolFallbackIndexes,
+    sanitizedMessageIndexes,
+  );
   propagateSanitizedToolNeighbors(messages, sanitizedMessageIndexes);
 
   const out: vscode.LanguageModelChatRequestMessage[] = [];
   const messageOriginIndexes: number[] = [];
   for (const [index, message] of messages.entries()) {
+    if (
+      !sanitizedMessageIndexes.has(index) &&
+      thinkingToolFallbackIndexes.has(index)
+    ) {
+      const sanitizedMessage = sanitizeThinkingToolCallMessage(message);
+      if (sanitizedMessage) {
+        out.push(sanitizedMessage);
+        messageOriginIndexes.push(index);
+      }
+      continue;
+    }
+
     if (!sanitizedMessageIndexes.has(index)) {
       out.push(message);
       messageOriginIndexes.push(index);
@@ -2993,11 +3080,7 @@ export function sanitizeMessagesForModelSwitchDetailed(
 
 export function sanitizeMessagesForModelSwitch(
   messages: readonly vscode.LanguageModelChatRequestMessage[],
-  options: {
-    modelId: string;
-    expectedIdentity: string;
-    imageRetention?: SanitizedImagePartRetention;
-  },
+  options: SanitizeMessagesForModelSwitchOptions,
 ): vscode.LanguageModelChatRequestMessage[] {
   return sanitizeMessagesForModelSwitchDetailed(messages, options).messages;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2827,19 +2827,69 @@ function sanitizeThinkingToolCallMessage(
   };
 }
 
-function markIncompleteThinkingToolExchanges(
-  messages: readonly vscode.LanguageModelChatRequestMessage[],
-  fallbackMessageIndexes: ReadonlySet<number>,
-  sanitizedMessageIndexes: Set<number>,
-): void {
-  const resultIds = new Set(messages.flatMap(collectExplicitToolResultIds));
+interface ExplicitToolExchange {
+  assistantMessageIndex: number;
+  resultMessageIndexes: number[];
+  complete: boolean;
+}
 
-  for (const index of fallbackMessageIndexes) {
-    const callIds = collectExplicitToolCallIds(messages[index]);
-    if (callIds.some((callId) => !resultIds.has(callId))) {
-      sanitizedMessageIndexes.add(index);
+function collectExplicitToolExchanges(
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+): ExplicitToolExchange[] {
+  const exchanges: ExplicitToolExchange[] = [];
+
+  // Call IDs may be reused later in the history. Only contiguous tool-result
+  // messages immediately following an assistant belong to that exchange.
+  for (const [assistantMessageIndex, message] of messages.entries()) {
+    const callIds = collectExplicitToolCallIds(message);
+    if (callIds.length === 0) {
+      continue;
     }
+
+    const expectedCallIds = new Set(callIds);
+    const resultCountByCallId = new Map<string, number>();
+    const resultMessageIndexes: number[] = [];
+    let hasUnexpectedResult = false;
+
+    for (
+      let resultMessageIndex = assistantMessageIndex + 1;
+      resultMessageIndex < messages.length;
+      resultMessageIndex++
+    ) {
+      const resultMessage = messages[resultMessageIndex];
+      if (resultMessage.role !== vscode.LanguageModelChatMessageRole.User) {
+        break;
+      }
+
+      const resultIds = collectExplicitToolResultIds(resultMessage);
+      if (resultIds.length === 0) {
+        break;
+      }
+
+      resultMessageIndexes.push(resultMessageIndex);
+      for (const resultId of resultIds) {
+        if (!expectedCallIds.has(resultId)) {
+          hasUnexpectedResult = true;
+          continue;
+        }
+        resultCountByCallId.set(
+          resultId,
+          (resultCountByCallId.get(resultId) ?? 0) + 1,
+        );
+      }
+    }
+
+    exchanges.push({
+      assistantMessageIndex,
+      resultMessageIndexes,
+      complete:
+        expectedCallIds.size === callIds.length &&
+        !hasUnexpectedResult &&
+        callIds.every((callId) => resultCountByCallId.get(callId) === 1),
+    });
   }
+
+  return exchanges;
 }
 
 function sanitizeMessageForModelSwitch(
@@ -2891,34 +2941,16 @@ function sanitizeMessageForModelSwitch(
 }
 
 function propagateSanitizedToolNeighbors(
-  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  exchanges: readonly ExplicitToolExchange[],
   sanitizedMessageIndexes: Set<number>,
 ): void {
-  const toolCallMessageIndexByCallId = new Map<string, number>();
-  const toolResultMessageIndexesByCallId = new Map<string, number[]>();
-
-  for (const [index, message] of messages.entries()) {
-    for (const callId of collectExplicitToolCallIds(message)) {
-      toolCallMessageIndexByCallId.set(callId, index);
-    }
-
-    for (const callId of collectExplicitToolResultIds(message)) {
-      const indexes = toolResultMessageIndexesByCallId.get(callId);
-      if (indexes) {
-        indexes.push(index);
-      } else {
-        toolResultMessageIndexesByCallId.set(callId, [index]);
-      }
-    }
-  }
-
   let changed = true;
   while (changed) {
     changed = false;
 
-    for (const [callId, callMessageIndex] of toolCallMessageIndexByCallId) {
-      const resultMessageIndexes =
-        toolResultMessageIndexesByCallId.get(callId) ?? [];
+    for (const exchange of exchanges) {
+      const callMessageIndex = exchange.assistantMessageIndex;
+      const resultMessageIndexes = exchange.resultMessageIndexes;
       const callMessageSanitized =
         sanitizedMessageIndexes.has(callMessageIndex);
       const hasSanitizedResultMessage = resultMessageIndexes.some((index) =>
@@ -2948,6 +2980,29 @@ export function sanitizeMessagesForModelSwitchDetailed(
 ): SanitizedMessagesForModelSwitchResult {
   const sanitizedMessageIndexes = new Set<number>();
   const thinkingToolFallbackIndexes = new Set<number>();
+  const toolExchanges = collectExplicitToolExchanges(messages);
+  const toolExchangeByAssistantIndex = new Map(
+    toolExchanges.map((exchange) => [
+      exchange.assistantMessageIndex,
+      exchange,
+    ]),
+  );
+  const preservedThinkingToolResultIndexes = new Set<number>();
+
+  if (options.preserveThinkingToolRounds) {
+    for (const exchange of toolExchanges) {
+      if (
+        exchange.complete &&
+        isThinkingToolCallMessage(
+          messages[exchange.assistantMessageIndex],
+        )
+      ) {
+        for (const resultMessageIndex of exchange.resultMessageIndexes) {
+          preservedThinkingToolResultIndexes.add(resultMessageIndex);
+        }
+      }
+    }
+  }
 
   let round: number[] = [];
   let roundHasAssistant = false;
@@ -2991,11 +3046,15 @@ export function sanitizeMessagesForModelSwitchDetailed(
       if (!isRoundValid) {
         for (const index of round) {
           const message = messages[index];
+          const exchange = toolExchangeByAssistantIndex.get(index);
           if (
             options.preserveThinkingToolRounds &&
+            exchange?.complete === true &&
             isThinkingToolCallMessage(message)
           ) {
             thinkingToolFallbackIndexes.add(index);
+          } else if (preservedThinkingToolResultIndexes.has(index)) {
+            continue;
           } else {
             sanitizedMessageIndexes.add(index);
           }
@@ -3033,12 +3092,7 @@ export function sanitizeMessagesForModelSwitchDetailed(
 
   flush();
 
-  markIncompleteThinkingToolExchanges(
-    messages,
-    thinkingToolFallbackIndexes,
-    sanitizedMessageIndexes,
-  );
-  propagateSanitizedToolNeighbors(messages, sanitizedMessageIndexes);
+  propagateSanitizedToolNeighbors(toolExchanges, sanitizedMessageIndexes);
 
   const out: vscode.LanguageModelChatRequestMessage[] = [];
   const messageOriginIndexes: number[] = [];

--- a/test/unit/deepseek-v4-reasoning-replay.test.ts
+++ b/test/unit/deepseek-v4-reasoning-replay.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const network = vi.hoisted(() => ({
   bodies: [] as Record<string, unknown>[],
+  responseMessage: { role: 'assistant', content: 'done' } as Record<
+    string,
+    unknown
+  >,
+  finishReason: 'stop',
   fetcher: (async () => new Response('', { status: 500 })) as typeof fetch,
 }));
 
@@ -224,9 +229,9 @@ function completionResponse(): Response {
       choices: [
         {
           index: 0,
-          finish_reason: 'stop',
+          finish_reason: network.finishReason,
           logprobs: null,
-          message: { role: 'assistant', content: 'done' },
+          message: network.responseMessage,
         },
       ],
     }),
@@ -237,14 +242,20 @@ function completionResponse(): Response {
   );
 }
 
-async function captureRequestBody(
+interface StreamChatCapture {
+  body: Record<string, unknown>;
+  parts: vscode.LanguageModelResponsePart2[];
+}
+
+async function runStreamChat(
   config: ProviderConfig,
   selectedModel: ModelConfig,
   messages: readonly vscode.LanguageModelChatRequestMessage[],
   requestModelId = encodedModelId,
-): Promise<Record<string, unknown>> {
+): Promise<StreamChatCapture> {
   const Provider = PROVIDER_TYPES['openai-chat-completion'].class;
   const provider = new Provider(config);
+  const parts: vscode.LanguageModelResponsePart2[] = [];
   for await (const part of provider.streamChat(
     requestModelId,
     selectedModel,
@@ -255,14 +266,24 @@ async function captureRequestBody(
     new SilentRequestLogger('deepseek-reasoning-replay'),
     { kind: 'token', token: 'test-token' },
   )) {
-    void part;
+    parts.push(part);
   }
 
   const body = network.bodies.at(-1);
   if (!body) {
     throw new Error('No Chat Completions request body was captured');
   }
-  return body;
+  return { body, parts };
+}
+
+async function captureRequestBody(
+  config: ProviderConfig,
+  selectedModel: ModelConfig,
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  requestModelId = encodedModelId,
+): Promise<Record<string, unknown>> {
+  return (await runStreamChat(config, selectedModel, messages, requestModelId))
+    .body;
 }
 
 function createMarker(
@@ -278,6 +299,65 @@ function createMarker(
     Buffer.from(`${encodedModelId}\\${encoded}`),
     DataPartMimeTypes.StatefulMarker,
   );
+}
+
+function materializeMarker(
+  marker: vscode.LanguageModelDataPart,
+  requestModelId = encodedModelId,
+): vscode.LanguageModelDataPart {
+  const serialized = Buffer.from(marker.data).toString('utf8');
+  const separatorIndex = serialized.indexOf('\\');
+  if (separatorIndex <= 0) {
+    throw new Error('Response marker did not contain a model prefix');
+  }
+
+  return new vscode.LanguageModelDataPart(
+    Buffer.from(
+      `${requestModelId}${serialized.slice(separatorIndex)}`,
+    ),
+    marker.mimeType,
+  );
+}
+
+function responseToolHistory(
+  parts: readonly vscode.LanguageModelResponsePart2[],
+  includeMarker: boolean,
+): vscode.LanguageModelChatRequestMessage[] {
+  const assistantContent: unknown[] = [];
+  for (const part of parts) {
+    if (
+      part instanceof vscode.LanguageModelDataPart &&
+      part.mimeType === DataPartMimeTypes.StatefulMarker
+    ) {
+      if (includeMarker) {
+        assistantContent.push(materializeMarker(part));
+      }
+      continue;
+    }
+    assistantContent.push(part);
+  }
+
+  return [
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new vscode.LanguageModelTextPart('question')],
+    },
+    {
+      role: vscode.LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: assistantContent,
+    },
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [
+        new vscode.LanguageModelToolResultPart('call-openrouter', [
+          new vscode.LanguageModelTextPart('openrouter result'),
+        ]),
+      ],
+    },
+  ];
 }
 
 function toolHistory(
@@ -331,6 +411,8 @@ function requestMessages(body: Record<string, unknown>): unknown[] {
 
 beforeEach(() => {
   network.bodies = [];
+  network.responseMessage = { role: 'assistant', content: 'done' };
+  network.finishReason = 'stop';
   network.fetcher = async (input, init) => {
     const request = new Request(input, init);
     const parsed: unknown = JSON.parse(await request.text());
@@ -343,8 +425,9 @@ beforeEach(() => {
 });
 
 describe('DeepSeek V4 reasoning replay', () => {
-  it('uses real feature matching for custom and ordinary model IDs', () => {
+  it('uses real feature matching for custom, ordinary, and OpenRouter models', () => {
     const config = providerConfig();
+    const openRouterConfig = providerConfig('https://openrouter.ai/api/v1');
 
     expect(
       isFeatureSupported(
@@ -360,6 +443,20 @@ describe('DeepSeek V4 reasoning replay', () => {
         model('ordinary-chat-model'),
       ),
     ).toBe(false);
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningDetails,
+        openRouterConfig,
+        model(),
+      ),
+    ).toBe(true);
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningContent,
+        openRouterConfig,
+        model(),
+      ),
+    ).toBe(true);
   });
 
   it.each([
@@ -457,60 +554,253 @@ describe('DeepSeek V4 reasoning replay', () => {
     ]);
   });
 
-  it('prefers OpenRouter reasoning_details and reindexes multiple thinking parts', async () => {
-    const config = providerConfig('https://openrouter.ai/api/v1');
-    const selectedModel = model();
+  it('replays two consecutive complete markerless tool exchanges', async () => {
+    const body = await captureRequestBody(providerConfig(), model(), [
+      {
+        role: vscode.LanguageModelChatMessageRole.User,
+        name: undefined,
+        content: [new vscode.LanguageModelTextPart('question')],
+      },
+      {
+        role: vscode.LanguageModelChatMessageRole.Assistant,
+        name: undefined,
+        content: [
+          new vscode.LanguageModelThinkingPart('first reasoning'),
+          new vscode.LanguageModelTextPart('First tool'),
+          new vscode.LanguageModelToolCallPart('call-first', 'lookup', {
+            query: 'first',
+          }),
+        ],
+      },
+      {
+        role: vscode.LanguageModelChatMessageRole.User,
+        name: undefined,
+        content: [
+          new vscode.LanguageModelToolResultPart('call-first', [
+            new vscode.LanguageModelTextPart('first result'),
+          ]),
+        ],
+      },
+      {
+        role: vscode.LanguageModelChatMessageRole.Assistant,
+        name: undefined,
+        content: [
+          new vscode.LanguageModelThinkingPart('second reasoning'),
+          new vscode.LanguageModelTextPart('Second tool'),
+          new vscode.LanguageModelToolCallPart('call-second', 'lookup', {
+            query: 'second',
+          }),
+        ],
+      },
+      {
+        role: vscode.LanguageModelChatMessageRole.User,
+        name: undefined,
+        content: [
+          new vscode.LanguageModelToolResultPart('call-second', [
+            new vscode.LanguageModelTextPart('second result'),
+          ]),
+        ],
+      },
+    ]);
 
-    expect(
-      isFeatureSupported(
-        FeatureId.OpenAIUseReasoningDetails,
-        config,
-        selectedModel,
-      ),
-    ).toBe(true);
-    expect(
-      isFeatureSupported(
-        FeatureId.OpenAIUseReasoningContent,
-        config,
-        selectedModel,
-      ),
-    ).toBe(true);
+    expect(requestMessages(body)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
+      },
+      {
+        role: 'assistant',
+        reasoning_content: 'first reasoning',
+        content: [{ type: 'text', text: 'First tool' }],
+        tool_calls: [
+          {
+            id: 'call-first',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"first"}' },
+          },
+        ],
+      },
+      { role: 'tool', content: 'first result', tool_call_id: 'call-first' },
+      {
+        role: 'assistant',
+        reasoning_content: 'second reasoning',
+        content: [{ type: 'text', text: 'Second tool' }],
+        tool_calls: [
+          {
+            id: 'call-second',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"second"}' },
+          },
+        ],
+      },
+      { role: 'tool', content: 'second result', tool_call_id: 'call-second' },
+    ]);
+  });
 
-    const body = await captureRequestBody(
-      config,
-      selectedModel,
-      toolHistory(),
-    );
-    const assistant = requestMessages(body)[1];
-
-    expect(assistant).toEqual({
-      role: 'assistant',
-      reasoning_details: [
-        { type: 'reasoning.text', index: 0, text: 'reason-1' },
-        { type: 'reasoning.text', index: 1, text: 'reason-2' },
-        { type: 'reasoning.text', index: 2, text: 'reason-3' },
+  it('does not satisfy a later reused call ID with an earlier result', async () => {
+    const history = toolHistory(undefined, ['call-1']);
+    history[1] = {
+      role: vscode.LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: [
+        new vscode.LanguageModelThinkingPart('first reasoning'),
+        new vscode.LanguageModelToolCallPart('call-1', 'lookup', {
+          query: 'first',
+        }),
       ],
-      content: [{ type: 'text', text: 'Calling tools' }],
-      tool_calls: [
-        {
-          id: 'call-1',
-          type: 'function',
-          function: {
-            name: 'lookup',
-            arguments: '{"query":"first"}',
-          },
-        },
-        {
-          id: 'call-2',
-          type: 'function',
-          function: {
-            name: 'lookup',
-            arguments: '{"query":"second"}',
-          },
-        },
+    };
+    history.push({
+      role: vscode.LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: [
+        new vscode.LanguageModelThinkingPart('incomplete reasoning'),
+        new vscode.LanguageModelToolCallPart('call-1', 'lookup', {
+          query: 'reused',
+        }),
       ],
     });
-    expect(assistant).not.toHaveProperty('reasoning_content');
+
+    const body = await captureRequestBody(providerConfig(), model(), history);
+
+    expect(requestMessages(body)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
+      },
+      {
+        role: 'assistant',
+        reasoning_content: 'first reasoning',
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"first"}' },
+          },
+        ],
+      },
+      { role: 'tool', content: 'first result', tool_call_id: 'call-1' },
+    ]);
+  });
+
+  it('restores extracted OpenRouter details exactly only through a valid marker', async () => {
+    const config = providerConfig('https://openrouter.ai/api/v1');
+    const selectedModel = model();
+    const raw = {
+      role: 'assistant',
+      content: null,
+      reasoning_details: [
+        {
+          type: 'reasoning.text',
+          index: 4,
+          text: 'signed reasoning',
+          signature: 'signature-value',
+        },
+        {
+          type: 'reasoning.encrypted',
+          index: 7,
+          data: 'encrypted-reasoning',
+        },
+      ],
+      tool_calls: [
+        {
+          id: 'call-openrouter',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"query":"openrouter"}',
+          },
+        },
+      ],
+    };
+    network.responseMessage = raw;
+    network.finishReason = 'tool_calls';
+
+    const extracted = await runStreamChat(config, selectedModel, [
+      {
+        role: vscode.LanguageModelChatMessageRole.User,
+        name: undefined,
+        content: [new vscode.LanguageModelTextPart('question')],
+      },
+    ]);
+    const thinkingParts = extracted.parts.filter(
+      (part): part is vscode.LanguageModelThinkingPart =>
+        part instanceof vscode.LanguageModelThinkingPart,
+    );
+    expect(thinkingParts.map((part) => part.value)).toEqual([
+      'signed reasoning',
+      '\nEncrypted thinking...',
+      '',
+    ]);
+    expect(thinkingParts.at(-1)?.metadata).toEqual({
+      _completeThinking: 'signed reasoning',
+      signature: 'signature-value',
+      redactedData: 'encrypted-reasoning',
+    });
+
+    network.responseMessage = { role: 'assistant', content: 'done' };
+    network.finishReason = 'stop';
+    const replay = await captureRequestBody(
+      config,
+      selectedModel,
+      responseToolHistory(extracted.parts, true),
+    );
+
+    expect(requestMessages(replay)[1]).toEqual(raw);
+  });
+
+  it('drops extracted OpenRouter details when the stateful marker is absent', async () => {
+    const config = providerConfig('https://openrouter.ai/api/v1');
+    const selectedModel = model();
+    network.responseMessage = {
+      role: 'assistant',
+      content: null,
+      reasoning_details: [
+        {
+          type: 'reasoning.text',
+          index: 0,
+          text: 'signed reasoning',
+          signature: 'signature-value',
+        },
+        {
+          type: 'reasoning.encrypted',
+          index: 1,
+          data: 'encrypted-reasoning',
+        },
+      ],
+      tool_calls: [
+        {
+          id: 'call-openrouter',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"query":"openrouter"}',
+          },
+        },
+      ],
+    };
+    network.finishReason = 'tool_calls';
+    const extracted = await runStreamChat(config, selectedModel, [
+      {
+        role: vscode.LanguageModelChatMessageRole.User,
+        name: undefined,
+        content: [new vscode.LanguageModelTextPart('question')],
+      },
+    ]);
+
+    network.responseMessage = { role: 'assistant', content: 'done' };
+    network.finishReason = 'stop';
+    const replay = await captureRequestBody(
+      config,
+      selectedModel,
+      responseToolHistory(extracted.parts, false),
+    );
+
+    expect(requestMessages(replay)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
+      },
+    ]);
   });
 
   it('does not retain an untrusted reasoning tool round for an ordinary model', async () => {

--- a/test/unit/deepseek-v4-reasoning-replay.test.ts
+++ b/test/unit/deepseek-v4-reasoning-replay.test.ts
@@ -1,7 +1,9 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
-import type { LanguageModelChatRequestMessage } from 'vscode';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const network = vi.hoisted(() => ({
+  bodies: [] as Record<string, unknown>[],
+  fetcher: (async () => new Response('', { status: 500 })) as typeof fetch,
+}));
 
 vi.mock('vscode', () => {
   class LanguageModelDataPart {
@@ -17,9 +19,9 @@ vi.mock('vscode', () => {
 
   class LanguageModelThinkingPart {
     constructor(
-      readonly value: string | readonly string[],
+      readonly value: string | string[],
       readonly id?: string,
-      readonly metadata?: Readonly<Record<string, unknown>>,
+      readonly metadata?: Record<string, unknown>,
     ) {}
   }
 
@@ -34,112 +36,266 @@ vi.mock('vscode', () => {
   class LanguageModelToolResultPart {
     constructor(
       readonly callId: string,
-      readonly content: readonly unknown[],
+      readonly content: unknown[],
     ) {}
   }
 
   return {
+    env: { language: 'en' },
+    extensions: { getExtension: () => undefined },
+    l10n: {
+      t: (message: string | { message: string }) =>
+        typeof message === 'string' ? message : message.message,
+    },
     LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelChatToolMode: { Auto: 1, Required: 2 },
     LanguageModelDataPart,
     LanguageModelTextPart,
     LanguageModelThinkingPart,
     LanguageModelToolCallPart,
     LanguageModelToolResultPart,
     LanguageModelToolResultPart2: LanguageModelToolResultPart,
+    window: {
+      createOutputChannel: () => ({
+        info: () => undefined,
+        error: () => undefined,
+        warn: () => undefined,
+        debug: () => undefined,
+        trace: () => undefined,
+        append: () => undefined,
+        appendLine: () => undefined,
+        replace: () => undefined,
+        clear: () => undefined,
+        show: () => undefined,
+        hide: () => undefined,
+        dispose: () => undefined,
+        name: 'test',
+        logLevel: 2,
+        onDidChangeLogLevel: () => ({ dispose: () => undefined }),
+      }),
+    },
+    workspace: {
+      getConfiguration: () => ({
+        get: <T>(_key: string, fallback: T) => fallback,
+      }),
+    },
   };
 });
 
-vi.mock('../../src/logger', () => ({
-  createSimpleHttpLogger: () => undefined,
+vi.mock('../../src/client/anthropic/client', () => ({
+  AnthropicProvider: class {},
+}));
+vi.mock('../../src/client/anthropic/claude-code-client', () => ({
+  AnthropicClaudeCodeProvider: class {},
+}));
+vi.mock('../../src/client/google/ai-studio-client', () => ({
+  GoogleAIStudioProvider: class {},
+}));
+vi.mock('../../src/client/google/antigravity-client', () => ({
+  GoogleAntigravityProvider: class {},
+}));
+vi.mock('../../src/client/google/gemini-cli-client', () => ({
+  GoogleGeminiCLIProvider: class {},
+}));
+vi.mock('../../src/client/google/vertex-ai-client', () => ({
+  VertexAIProvider: class {},
+}));
+vi.mock('../../src/client/github-copilot/client', () => ({
+  GitHubCopilotProvider: class {},
+}));
+vi.mock('../../src/client/ollama/client', () => ({
+  OllamaProvider: class {},
+}));
+vi.mock('../../src/client/openai/codex-client', () => ({
+  OpenAICodexProvider: class {},
+}));
+vi.mock('../../src/client/openai/responses-client', () => ({
+  OpenAIResponsesProvider: class {},
+}));
+vi.mock('../../src/client/xai/grok-build-client', () => ({
+  XaiGrokBuildProvider: class {},
+}));
+vi.mock('../../src/client/zed/provider', () => ({
+  ZedProvider: class {},
+}));
+vi.mock('../../src/config-store', () => ({
+  CONFIG_NAMESPACE: 'unifyChatProvider',
+}));
+vi.mock('../../src/official-models-manager', () => ({
+  officialModelsManager: {},
 }));
 
-vi.mock('../../src/client/types', () => ({
-  ENCRYPTED_THINKING_PLACEHOLDER: 'Encrypted thinking...',
-}));
-
-vi.mock('../../src/client/definitions', () => ({
-  FeatureId: {},
-}));
-
-vi.mock('../../src/model-id-utils', () => ({
-  getBaseModelId: (id: string) => id,
-}));
-
-vi.mock('../../src/client/utils', () => ({
-  buildBaseUrl: (baseUrl: string) => baseUrl,
-  isFeatureSupportedByProvider: () => false,
-}));
-
-vi.mock('../../src/utils', () => ({
-  DEFAULT_CONTEXT_CACHE_TTL_SECONDS: 300,
-  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
-    connection: 10_000,
-    response: 300_000,
-  },
-  decodeStatefulMarkerPart: () => {
-    throw new Error('No stateful marker is expected in this test');
-  },
-  isCacheControlMarker: () => false,
-  isImageMarker: () => false,
-  isInternalMarker: () => false,
-  isRawBaseUrlEnabled: () => false,
-  isUsageMarker: () => false,
-  normalizeImageMimeType: () => undefined,
-  tryNormalizeCopilotUsage: () => undefined,
-}));
+vi.mock('../../src/client/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/client/utils')>();
+  return {
+    ...actual,
+    createCustomFetch: () => network.fetcher,
+  };
+});
 
 import * as vscode from 'vscode';
-import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+import { FeatureId, PROVIDER_TYPES } from '../../src/client/definitions';
+import { isFeatureSupported } from '../../src/client/utils';
+import { DataPartMimeTypes } from '../../src/client/types';
+import { RequestLogger } from '../../src/logger';
+import type {
+  ChatRequestTrace,
+  ModelConfig,
+  ProviderConfig,
+} from '../../src/types';
+import { createStatefulMarkerIdentity } from '../../src/utils';
 
-class TestDeepSeekProvider extends OpenAIChatCompletionProvider {
-  replayAssistantHistory(
-    messages: readonly LanguageModelChatRequestMessage[],
-  ) {
-    return this.convertMessages(
-      'custom/deepseek-v4-pro',
-      messages,
-      false,
-      'content',
-      'deepseek-v4-test',
-    );
-  }
+const encodedModelId = 'custom/deepseek-v4-pro';
+
+class SilentRequestLogger extends RequestLogger {
+  override providerRequest(_details: {
+    endpoint: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+  }): void {}
+
+  override providerResponseMeta(_response: Response): void {}
+  override providerResponseChunk(_chunk: string): void {}
+  override vscodeOutput(_part: vscode.LanguageModelResponsePart2): void {}
 }
 
-function getFeatureBlock(source: string, featureId: string): string {
-  const marker = `[FeatureId.${featureId}]: {`;
-  const start = source.indexOf(marker);
-  if (start < 0) {
-    throw new Error(`Feature ${featureId} was not found`);
-  }
-
-  const rest = source.slice(start);
-  const end = rest.indexOf('\n  },\n  [FeatureId.');
-  return end < 0 ? rest : rest.slice(0, end);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-describe('DeepSeek V4 reasoning replay', () => {
-  it('enables reasoning_content for DeepSeek V4 on custom endpoints', () => {
-    const source = readFileSync(
-      resolve(process.cwd(), 'src/client/definitions.ts'),
-      'utf8',
-    );
+function providerConfig(baseUrl = 'https://custom.example/v1'): ProviderConfig {
+  return {
+    type: 'openai-chat-completion',
+    name: 'Reasoning replay test',
+    baseUrl,
+    models: [],
+  };
+}
 
-    expect(getFeatureBlock(source, 'OpenAIUseReasoningContent')).toContain(
-      "modelFamilyIncludes(model, 'deepseek-v4')",
-    );
-  });
+function model(id = 'deepseek-v4-pro'): ModelConfig {
+  return {
+    id,
+    maxInputTokens: 100_000,
+    maxOutputTokens: 4096,
+    stream: false,
+    thinking: { type: 'enabled', effort: 'high' },
+    capabilities: { toolCalling: true },
+  };
+}
 
-  it('replays reasoning, content, and tool calls in one assistant message', () => {
-    const provider = new TestDeepSeekProvider({
-      type: 'openai-chat-completion',
-      name: 'Custom DeepSeek',
-      baseUrl: 'https://custom.example/v1',
-      models: [],
-    });
-    const assistantHistory: LanguageModelChatRequestMessage = {
+function trace(): ChatRequestTrace {
+  return {
+    performance: { tts: Date.now(), ttf: 0, ttft: 0, tps: 0, tl: 0 },
+  };
+}
+
+function cancellationToken(): vscode.CancellationToken {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose: () => undefined }),
+  };
+}
+
+function options(): vscode.ProvideLanguageModelChatResponseOptions {
+  return {
+    requestInitiator: 'test',
+    toolMode: vscode.LanguageModelChatToolMode.Auto,
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup a value',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+        },
+      },
+    ],
+  };
+}
+
+function completionResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-test',
+      object: 'chat.completion',
+      created: 0,
+      model: 'test-model',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          logprobs: null,
+          message: { role: 'assistant', content: 'done' },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
+async function captureRequestBody(
+  config: ProviderConfig,
+  selectedModel: ModelConfig,
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  requestModelId = encodedModelId,
+): Promise<Record<string, unknown>> {
+  const Provider = PROVIDER_TYPES['openai-chat-completion'].class;
+  const provider = new Provider(config);
+  for await (const part of provider.streamChat(
+    requestModelId,
+    selectedModel,
+    messages,
+    options(),
+    trace(),
+    cancellationToken(),
+    new SilentRequestLogger('deepseek-reasoning-replay'),
+    { kind: 'token', token: 'test-token' },
+  )) {
+    void part;
+  }
+
+  const body = network.bodies.at(-1);
+  if (!body) {
+    throw new Error('No Chat Completions request body was captured');
+  }
+  return body;
+}
+
+function createMarker(
+  config: ProviderConfig,
+  selectedModel: ModelConfig,
+  raw: Record<string, unknown>,
+  identity = createStatefulMarkerIdentity(config, selectedModel),
+): vscode.LanguageModelDataPart {
+  const encoded = Buffer.from(
+    JSON.stringify({ identity, data: { data: raw } }),
+  ).toString('base64');
+  return new vscode.LanguageModelDataPart(
+    Buffer.from(`${encodedModelId}\\${encoded}`),
+    DataPartMimeTypes.StatefulMarker,
+  );
+}
+
+function toolHistory(
+  marker?: vscode.LanguageModelDataPart,
+  resultCallIds: readonly ('call-1' | 'call-2')[] = ['call-1', 'call-2'],
+): vscode.LanguageModelChatRequestMessage[] {
+  return [
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new vscode.LanguageModelTextPart('question')],
+    },
+    {
       role: vscode.LanguageModelChatMessageRole.Assistant,
+      name: undefined,
       content: [
-        new vscode.LanguageModelThinkingPart('private reasoning'),
+        new vscode.LanguageModelThinkingPart('reason-1'),
+        new vscode.LanguageModelThinkingPart(['reason-2', 'reason-3']),
         new vscode.LanguageModelTextPart('Calling tools'),
         new vscode.LanguageModelToolCallPart('call-1', 'lookup', {
           query: 'first',
@@ -147,14 +303,91 @@ describe('DeepSeek V4 reasoning replay', () => {
         new vscode.LanguageModelToolCallPart('call-2', 'lookup', {
           query: 'second',
         }),
+        ...(marker ? [marker] : []),
       ],
+    },
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
       name: undefined,
-    };
+      content: resultCallIds.map(
+        (callId) =>
+          new vscode.LanguageModelToolResultPart(callId, [
+            new vscode.LanguageModelTextPart(
+              callId === 'call-1' ? 'first result' : 'second result',
+            ),
+          ]),
+      ),
+    },
+  ];
+}
 
-    expect(provider.replayAssistantHistory([assistantHistory])).toEqual([
+function requestMessages(body: Record<string, unknown>): unknown[] {
+  const messages = body['messages'];
+  if (!Array.isArray(messages)) {
+    throw new Error('Captured request did not contain a messages array');
+  }
+  return messages;
+}
+
+beforeEach(() => {
+  network.bodies = [];
+  network.fetcher = async (input, init) => {
+    const request = new Request(input, init);
+    const parsed: unknown = JSON.parse(await request.text());
+    if (!isRecord(parsed)) {
+      throw new Error('Chat Completions request body must be an object');
+    }
+    network.bodies.push(parsed);
+    return completionResponse();
+  };
+});
+
+describe('DeepSeek V4 reasoning replay', () => {
+  it('uses real feature matching for custom and ordinary model IDs', () => {
+    const config = providerConfig();
+
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningContent,
+        config,
+        model(),
+      ),
+    ).toBe(true);
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningContent,
+        config,
+        model('ordinary-chat-model'),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    { name: 'without a marker', marker: undefined },
+    {
+      name: 'with an invalid marker',
+      marker: createMarker(
+        providerConfig(),
+        model(),
+        { role: 'assistant', content: 'stale' },
+        'wrong-identity',
+      ),
+    },
+  ])('replays a complete multi-tool turn $name', async ({ marker }) => {
+    const body = await captureRequestBody(
+      providerConfig(),
+      model(),
+      toolHistory(marker),
+    );
+
+    expect(requestMessages(body)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
+      },
       {
         role: 'assistant',
-        reasoning_content: 'private reasoning',
+        reasoning_content: 'reason-1reason-2reason-3',
         content: [{ type: 'text', text: 'Calling tools' }],
         tool_calls: [
           {
@@ -174,6 +407,124 @@ describe('DeepSeek V4 reasoning replay', () => {
             },
           },
         ],
+      },
+      { role: 'tool', content: 'first result', tool_call_id: 'call-1' },
+      { role: 'tool', content: 'second result', tool_call_id: 'call-2' },
+    ]);
+  });
+
+  it('keeps valid stateful raw data authoritative, including null content', async () => {
+    const config = providerConfig();
+    const selectedModel = model();
+    const raw = {
+      role: 'assistant',
+      content: null,
+      reasoning_content: 'raw reasoning',
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"raw first"}' },
+        },
+        {
+          id: 'call-2',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"raw second"}' },
+        },
+      ],
+    };
+    const body = await captureRequestBody(
+      config,
+      selectedModel,
+      toolHistory(createMarker(config, selectedModel, raw)),
+    );
+
+    expect(requestMessages(body)[1]).toEqual(raw);
+  });
+
+  it('drops the whole fallback exchange when one tool result is missing', async () => {
+    const body = await captureRequestBody(
+      providerConfig(),
+      model(),
+      toolHistory(undefined, ['call-1']),
+    );
+
+    expect(requestMessages(body)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
+      },
+    ]);
+  });
+
+  it('prefers OpenRouter reasoning_details and reindexes multiple thinking parts', async () => {
+    const config = providerConfig('https://openrouter.ai/api/v1');
+    const selectedModel = model();
+
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningDetails,
+        config,
+        selectedModel,
+      ),
+    ).toBe(true);
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseReasoningContent,
+        config,
+        selectedModel,
+      ),
+    ).toBe(true);
+
+    const body = await captureRequestBody(
+      config,
+      selectedModel,
+      toolHistory(),
+    );
+    const assistant = requestMessages(body)[1];
+
+    expect(assistant).toEqual({
+      role: 'assistant',
+      reasoning_details: [
+        { type: 'reasoning.text', index: 0, text: 'reason-1' },
+        { type: 'reasoning.text', index: 1, text: 'reason-2' },
+        { type: 'reasoning.text', index: 2, text: 'reason-3' },
+      ],
+      content: [{ type: 'text', text: 'Calling tools' }],
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"query":"first"}',
+          },
+        },
+        {
+          id: 'call-2',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"query":"second"}',
+          },
+        },
+      ],
+    });
+    expect(assistant).not.toHaveProperty('reasoning_content');
+  });
+
+  it('does not retain an untrusted reasoning tool round for an ordinary model', async () => {
+    const body = await captureRequestBody(
+      providerConfig(),
+      model('ordinary-chat-model'),
+      toolHistory(),
+      'custom/ordinary-chat-model',
+    );
+
+    expect(requestMessages(body)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'question' }],
       },
     ]);
   });

--- a/test/unit/deepseek-v4-reasoning-replay.test.ts
+++ b/test/unit/deepseek-v4-reasoning-replay.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { LanguageModelChatRequestMessage } from 'vscode';
+
+vi.mock('vscode', () => {
+  class LanguageModelDataPart {
+    constructor(
+      readonly data: Uint8Array,
+      readonly mimeType: string,
+    ) {}
+  }
+
+  class LanguageModelTextPart {
+    constructor(readonly value: string) {}
+  }
+
+  class LanguageModelThinkingPart {
+    constructor(
+      readonly value: string | readonly string[],
+      readonly id?: string,
+      readonly metadata?: Readonly<Record<string, unknown>>,
+    ) {}
+  }
+
+  class LanguageModelToolCallPart {
+    constructor(
+      readonly callId: string,
+      readonly name: string,
+      readonly input: object,
+    ) {}
+  }
+
+  class LanguageModelToolResultPart {
+    constructor(
+      readonly callId: string,
+      readonly content: readonly unknown[],
+    ) {}
+  }
+
+  return {
+    LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelDataPart,
+    LanguageModelTextPart,
+    LanguageModelThinkingPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelToolResultPart2: LanguageModelToolResultPart,
+  };
+});
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => undefined,
+}));
+
+vi.mock('../../src/client/types', () => ({
+  ENCRYPTED_THINKING_PLACEHOLDER: 'Encrypted thinking...',
+}));
+
+vi.mock('../../src/client/definitions', () => ({
+  FeatureId: {},
+}));
+
+vi.mock('../../src/model-id-utils', () => ({
+  getBaseModelId: (id: string) => id,
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  buildBaseUrl: (baseUrl: string) => baseUrl,
+  isFeatureSupportedByProvider: () => false,
+}));
+
+vi.mock('../../src/utils', () => ({
+  DEFAULT_CONTEXT_CACHE_TTL_SECONDS: 300,
+  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
+    connection: 10_000,
+    response: 300_000,
+  },
+  decodeStatefulMarkerPart: () => {
+    throw new Error('No stateful marker is expected in this test');
+  },
+  isCacheControlMarker: () => false,
+  isImageMarker: () => false,
+  isInternalMarker: () => false,
+  isRawBaseUrlEnabled: () => false,
+  isUsageMarker: () => false,
+  normalizeImageMimeType: () => undefined,
+  tryNormalizeCopilotUsage: () => undefined,
+}));
+
+import * as vscode from 'vscode';
+import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+
+class TestDeepSeekProvider extends OpenAIChatCompletionProvider {
+  replayAssistantHistory(
+    messages: readonly LanguageModelChatRequestMessage[],
+  ) {
+    return this.convertMessages(
+      'custom/deepseek-v4-pro',
+      messages,
+      false,
+      'content',
+      'deepseek-v4-test',
+    );
+  }
+}
+
+function getFeatureBlock(source: string, featureId: string): string {
+  const marker = `[FeatureId.${featureId}]: {`;
+  const start = source.indexOf(marker);
+  if (start < 0) {
+    throw new Error(`Feature ${featureId} was not found`);
+  }
+
+  const rest = source.slice(start);
+  const end = rest.indexOf('\n  },\n  [FeatureId.');
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe('DeepSeek V4 reasoning replay', () => {
+  it('enables reasoning_content for DeepSeek V4 on custom endpoints', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/client/definitions.ts'),
+      'utf8',
+    );
+
+    expect(getFeatureBlock(source, 'OpenAIUseReasoningContent')).toContain(
+      "modelFamilyIncludes(model, 'deepseek-v4')",
+    );
+  });
+
+  it('replays reasoning, content, and tool calls in one assistant message', () => {
+    const provider = new TestDeepSeekProvider({
+      type: 'openai-chat-completion',
+      name: 'Custom DeepSeek',
+      baseUrl: 'https://custom.example/v1',
+      models: [],
+    });
+    const assistantHistory: LanguageModelChatRequestMessage = {
+      role: vscode.LanguageModelChatMessageRole.Assistant,
+      content: [
+        new vscode.LanguageModelThinkingPart('private reasoning'),
+        new vscode.LanguageModelTextPart('Calling tools'),
+        new vscode.LanguageModelToolCallPart('call-1', 'lookup', {
+          query: 'first',
+        }),
+        new vscode.LanguageModelToolCallPart('call-2', 'lookup', {
+          query: 'second',
+        }),
+      ],
+      name: undefined,
+    };
+
+    expect(provider.replayAssistantHistory([assistantHistory])).toEqual([
+      {
+        role: 'assistant',
+        reasoning_content: 'private reasoning',
+        content: [{ type: 'text', text: 'Calling tools' }],
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"first"}',
+            },
+          },
+          {
+            id: 'call-2',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"second"}',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- enable `reasoning_content` replay for the DeepSeek V4 model family on custom OpenAI-compatible endpoints
- preserve complete markerless DeepSeek reasoning + multi-tool exchanges and merge each assistant turn into one Chat Completions message
- pair tool calls and results within their local ordered exchange, so reused call IDs and consecutive tool rounds cannot affect each other
- keep OpenRouter `reasoning_details` lossless by replaying signed/encrypted details only from a valid raw stateful marker
- add real `streamChat` request-body regressions, including an OpenRouter response extraction and replay cycle

## Root cause

`OpenAIUseReasoningContent` was selected primarily from a provider URL allowlist. A custom endpoint serving `deepseek-v4-pro` therefore selected no historical reasoning field and discarded thinking parts.

Two history boundaries also prevented a correct tool continuation:

1. `sanitizeMessagesForModelSwitch` deleted an entire assistant tool round when VS Code omitted or damaged its stateful marker.
2. Best-effort conversion emitted each surviving assistant content part as a separate Chat Completions message, so the message containing `tool_calls` did not carry the preceding reasoning field.

## Safety boundaries

- a valid stateful marker remains authoritative and its raw assistant message is replayed unchanged, including `content: null`
- markerless fallback is limited to the `reasoning_content` protocol and assistant messages containing both thinking and explicit tool calls
- each fallback call must have exactly one result in the contiguous user result messages immediately following that assistant; duplicate, unexpected, or missing results reject the exchange
- repeated call IDs in later exchanges cannot be satisfied by earlier results
- results from one complete markerless exchange remain intact when the next markerless tool exchange begins
- OpenRouter `reasoning_details` never use best-effort thinking-part reconstruction; valid markers preserve original indexes, order, signatures, and encrypted data
- invalid/internal markers and unknown parts are stripped from fallback messages, while ordinary models retain conservative sanitization

## Validation

- `npm run test:unit -- --run test/unit/deepseek-v4-reasoning-replay.test.ts test/unit/message-sanitization.test.ts` (2 files, 14 tests passed)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `npm run verify:chat-lib`
- `npm run l10n:check`
- `git diff --check`

`npm test` passed 104 of 105 files and 1241 of 1242 tests. The sole failure is an unrelated current-`main` baseline in `plan4-provider-catalog.test.ts`: `deepseek-v4-flash-vision-exp` has no FIM completion template. The same assertion fails in a clean `origin/main@616a3bd` worktree.

Fixes #289
