### PR TITLE
fix(nvidia): cap DeepSeek V4 Pro output tokens

### DIFF
--- a/src/well-known/models.ts
+++ b/src/well-known/models.ts
@@ -2428,7 +2428,7 @@ const _WELL_KNOWN_MODELS = [
         matchers: ['integrate.api.nvidia.com'],
         config: {
           id: 'deepseek-ai/deepseek-v4-pro',
-          maxOutputTokens: 262144,
+          maxOutputTokens: 16384,
         },
       },
     ],

--- a/test/unit/nvidia-deepseek-v4-pro.test.ts
+++ b/test/unit/nvidia-deepseek-v4-pro.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+}));
+
+import {
+  mergeWithWellKnownModel,
+  normalizeWellKnownConfigs,
+  WELL_KNOWN_MODELS,
+} from '../../src/well-known/models';
+import type { ProviderConfig } from '../../src/types';
+
+const NVIDIA_PROVIDER: ProviderConfig = {
+  name: 'Nvidia',
+  type: 'openai-chat-completion',
+  baseUrl: 'https://integrate.api.nvidia.com',
+  models: [],
+};
+
+describe('NVIDIA DeepSeek V4 Pro catalog override', () => {
+  it('uses the NVIDIA API output limit for the built-in model', () => {
+    const deepSeekV4Pro = WELL_KNOWN_MODELS.filter(
+      (model) => model.id === 'deepseek-v4-pro',
+    );
+
+    expect(
+      normalizeWellKnownConfigs(deepSeekV4Pro, undefined, NVIDIA_PROVIDER),
+    ).toMatchObject([
+      {
+        id: 'deepseek-ai/deepseek-v4-pro',
+        maxOutputTokens: 16384,
+      },
+    ]);
+  });
+
+  it('applies the same limit to an API-discovered NVIDIA model', () => {
+    expect(
+      mergeWithWellKnownModel(
+        { id: 'deepseek-ai/deepseek-v4-pro' },
+        NVIDIA_PROVIDER,
+      ),
+    ).toMatchObject({
+      id: 'deepseek-ai/deepseek-v4-pro',
+      maxOutputTokens: 16384,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- cap the NVIDIA-specific `deepseek-ai/deepseek-v4-pro` output limit at `16384`
- keep the DeepSeek direct-provider limit and other NVIDIA DeepSeek models unchanged
- add regression coverage for built-in normalization and API-discovered model merging

## Root cause

The NVIDIA provider override set `maxOutputTokens` to `262144`. The Chat Completions client consequently sent that value as the request output limit, exceeding the current NVIDIA API constraint and causing requests to fail.

NVIDIA currently documents `max_tokens` for this model as an integer from `1` through `16384`:

https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-pro-infer

## Validation

- `npx vitest run test/unit/nvidia-deepseek-v4-pro.test.ts` (2 passed)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `npx vitest run --exclude test/unit/plan4-provider-catalog.test.ts` (104 files, 1227 tests passed)
- `git diff --check`

`npm test` completed both TypeScript checks, the strict release check, and the chat-lib runtime build before Vitest reported one unrelated existing failure in `test/unit/plan4-provider-catalog.test.ts`. Clean `origin/main@616a3bd` reproduces the same assertion because `deepseek-v4-flash-vision-exp` has no FIM completion template.

Fixes #282