### PR TITLE
fix(opencode): partition discovered models by protocol

### DIFF
--- a/src/main-instance/protocol.ts
+++ b/src/main-instance/protocol.ts
@@ -8,7 +8,7 @@ export const PROTOCOL_VERSION = 1 as const;
  * when IPC/RPC message contracts, shared state contracts, or leader/follower
  * behavior become incompatible across extension instances.
  */
-export const MAIN_INSTANCE_COMPATIBILITY_VERSION = 7 as const;
+export const MAIN_INSTANCE_COMPATIBILITY_VERSION = 8 as const;
 
 export type HelloMessage = {
   type: 'hello';

--- a/src/main-instance/register-handlers.ts
+++ b/src/main-instance/register-handlers.ts
@@ -1012,6 +1012,11 @@ export function parseOfficialModelsFetchState(
   method: string,
 ): OfficialModelsFetchState {
   const record = requireRecord(value, method);
+  const modelsProcessingRevision = requireNumber(
+    record['modelsProcessingRevision'],
+    method,
+    'state.modelsProcessingRevision',
+  );
   const lastFetchTime = requireNumber(
     record['lastFetchTime'],
     method,
@@ -1084,6 +1089,7 @@ export function parseOfficialModelsFetchState(
   }
 
   return {
+    modelsProcessingRevision,
     lastFetchTime,
     models: parseModels(record['models'], method, 'state.models'),
     modelsHash,

--- a/src/official-models-manager.ts
+++ b/src/official-models-manager.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import { ModelConfig, ProviderConfig } from './types';
 import { createProvider } from './client/utils';
-import { prepareOfficialModels } from './well-known/opencode-models';
+import {
+  OPENCODE_PROTOCOL_RULES_REVISION,
+  prepareOfficialModels,
+} from './well-known/opencode-models';
 import { stableStringify } from './config-ops';
 import { SecretStore } from './secret';
 import {
@@ -36,6 +39,8 @@ import type { ConfigStore } from './config-store';
  * State for a single provider's official models fetch
  */
 export interface OfficialModelsFetchState {
+  /** Revision of the model normalization/filtering rules applied to models */
+  modelsProcessingRevision: number;
   /** Last successful fetch timestamp (ms) */
   lastFetchTime: number;
   /** Last fetch attempt timestamp (ms), includes both success and failure */
@@ -159,6 +164,9 @@ const FETCH_CONFIG = {
   /** Multiplier for interval when errors continue */
   errorBackoffMultiplier: 2,
 };
+
+export const OFFICIAL_MODELS_PROCESSING_REVISION =
+  OPENCODE_PROTOCOL_RULES_REVISION;
 
 const STATE_KEY = 'officialModelsState';
 
@@ -701,8 +709,31 @@ export class OfficialModelsManager {
     if (!this.extensionContext) return;
     const persisted =
       this.extensionContext.globalState.get<PersistedState>(STATE_KEY);
-    if (persisted) {
-      this.state = persisted;
+    if (!persisted) {
+      return;
+    }
+
+    let migrated = false;
+    const nextState: PersistedState = {};
+    for (const [providerName, state] of Object.entries(persisted)) {
+      if (
+        state.modelsProcessingRevision ===
+        OFFICIAL_MODELS_PROCESSING_REVISION
+      ) {
+        nextState[providerName] = state;
+        continue;
+      }
+
+      // Older caches may contain output from prior processing rules. The raw
+      // catalog is not stored separately, so invalidate instead of attempting
+      // a lossy reprocessing migration.
+      nextState[providerName] = this.createInitialFetchState();
+      migrated = true;
+    }
+    this.state = nextState;
+
+    if (migrated) {
+      await this.saveState();
     }
   }
 
@@ -1357,18 +1388,23 @@ export class OfficialModelsManager {
   /**
    * Ensure a state exists for the provider
    */
+  private createInitialFetchState(): OfficialModelsFetchState {
+    return {
+      modelsProcessingRevision: OFFICIAL_MODELS_PROCESSING_REVISION,
+      lastFetchTime: 0,
+      lastAttemptTime: 0,
+      models: [],
+      modelsHash: '',
+      consecutiveIdenticalFetches: 0,
+      currentIntervalMs: FETCH_CONFIG.initialIntervalMs,
+      consecutiveErrorFetches: 0,
+      currentErrorIntervalMs: FETCH_CONFIG.errorInitialIntervalMs,
+    };
+  }
+
   private ensureState(providerName: string): OfficialModelsFetchState {
     if (!this.state[providerName]) {
-      this.state[providerName] = {
-        lastFetchTime: 0,
-        lastAttemptTime: 0,
-        models: [],
-        modelsHash: '',
-        consecutiveIdenticalFetches: 0,
-        currentIntervalMs: FETCH_CONFIG.initialIntervalMs,
-        consecutiveErrorFetches: 0,
-        currentErrorIntervalMs: FETCH_CONFIG.errorInitialIntervalMs,
-      };
+      this.state[providerName] = this.createInitialFetchState();
     }
     return this.state[providerName];
   }
@@ -1577,16 +1613,7 @@ export class OfficialModelsManager {
     let session = this.draftSessions.get(sessionId);
     if (!session) {
       session = {
-        state: {
-          lastFetchTime: 0,
-          lastAttemptTime: 0,
-          models: [],
-          modelsHash: '',
-          consecutiveIdenticalFetches: 0,
-          currentIntervalMs: FETCH_CONFIG.initialIntervalMs,
-          consecutiveErrorFetches: 0,
-          currentErrorIntervalMs: FETCH_CONFIG.errorInitialIntervalMs,
-        },
+        state: this.createInitialFetchState(),
         // Placeholder signature; real signature is set when a fetch is triggered.
         configSignature: {
           type: '',

--- a/src/official-models-manager.ts
+++ b/src/official-models-manager.ts
@@ -5,6 +5,10 @@ import {
   OPENCODE_PROTOCOL_RULES_REVISION,
   prepareOfficialModels,
 } from './well-known/opencode-models';
+import {
+  fetchOpenCodeCatalog,
+  isOpenCodeCatalogProvider,
+} from './well-known/opencode-catalog';
 import { stableStringify } from './config-ops';
 import { SecretStore } from './secret';
 import {
@@ -876,6 +880,31 @@ export class OfficialModelsManager {
     }
   }
 
+  private async fetchAvailableModels(
+    provider: ProviderConfig,
+    credentialAccess: OfficialModelsCredentialAccess,
+    signal: AbortSignal,
+  ): Promise<ModelConfig[]> {
+    if (isOpenCodeCatalogProvider(provider)) {
+      return fetchOpenCodeCatalog(
+        provider,
+        credentialAccess.credential,
+        signal,
+      );
+    }
+
+    const client = createProvider(provider);
+    if (!client.getAvailableModels) {
+      throw new Error(t('Provider does not support fetching available models'));
+    }
+
+    return client.getAvailableModels(
+      credentialAccess.credential,
+      credentialAccess.refreshCredential,
+      signal,
+    );
+  }
+
   /**
    * Fetch official models for a provider
    * Returns cached models if within interval, fetches new ones otherwise
@@ -1108,17 +1137,9 @@ export class OfficialModelsManager {
         return state.models;
       }
 
-      const client = createProvider(provider);
-
-      if (!client.getAvailableModels) {
-        throw new Error(
-          t('Provider does not support fetching available models'),
-        );
-      }
-
-      const rawModels = await client.getAvailableModels(
-        credentialAccess.credential,
-        credentialAccess.refreshCredential,
+      const rawModels = await this.fetchAvailableModels(
+        provider,
+        credentialAccess,
         fetchContext.controller.signal,
       );
       const models = prepareOfficialModels(rawModels, provider);
@@ -1776,17 +1797,9 @@ export class OfficialModelsManager {
         return session.state.models;
       }
 
-      const client = createProvider(provider);
-
-      if (!client.getAvailableModels) {
-        throw new Error(
-          t('Provider does not support fetching available models'),
-        );
-      }
-
-      const rawModels = await client.getAvailableModels(
-        credentialAccess.credential,
-        credentialAccess.refreshCredential,
+      const rawModels = await this.fetchAvailableModels(
+        provider,
+        credentialAccess,
         fetchContext.controller.signal,
       );
       const models = prepareOfficialModels(rawModels, provider);

--- a/src/official-models-manager.ts
+++ b/src/official-models-manager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ModelConfig, ProviderConfig } from './types';
 import { createProvider } from './client/utils';
-import { mergeWithWellKnownModels } from './well-known/models';
+import { prepareOfficialModels } from './well-known/opencode-models';
 import { stableStringify } from './config-ops';
 import { SecretStore } from './secret';
 import {
@@ -1090,7 +1090,7 @@ export class OfficialModelsManager {
         credentialAccess.refreshCredential,
         fetchContext.controller.signal,
       );
-      const models = mergeWithWellKnownModels(rawModels, provider);
+      const models = prepareOfficialModels(rawModels, provider);
       const modelsHash = this.hashModels(models);
 
       const isIdentical = state.modelsHash === modelsHash;
@@ -1762,7 +1762,7 @@ export class OfficialModelsManager {
         credentialAccess.refreshCredential,
         fetchContext.controller.signal,
       );
-      const models = mergeWithWellKnownModels(rawModels, provider);
+      const models = prepareOfficialModels(rawModels, provider);
       const now = Date.now();
       if (!this.isDraftFetchCurrent(sessionId, fetchContext)) {
         return session.state.models;

--- a/src/well-known/opencode-catalog.ts
+++ b/src/well-known/opencode-catalog.ts
@@ -1,0 +1,140 @@
+import type { AuthTokenInfo } from '../auth/types';
+import {
+  createCustomFetch,
+  getToken,
+  getTokenType,
+  getUnifiedUserAgent,
+  mergeHeaders,
+  setUserAgentHeader,
+} from '../client/utils';
+import { createSimpleHttpLogger } from '../logger';
+import type { ModelConfig, ProviderConfig } from '../types';
+import {
+  DEFAULT_NORMAL_TIMEOUT_CONFIG,
+  resolveChatNetwork,
+} from '../utils';
+import { getOpenCodeService } from './opencode-models';
+
+export type OpenCodeCatalogFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isOpenCodeCatalogProvider(provider: ProviderConfig): boolean {
+  return getOpenCodeService(provider.baseUrl) !== undefined;
+}
+
+export function getOpenCodeCatalogUrl(
+  provider: ProviderConfig,
+): string | undefined {
+  const service = getOpenCodeService(provider.baseUrl);
+  if (!service) {
+    return undefined;
+  }
+
+  const url = new URL(provider.baseUrl.trim());
+  url.pathname = service === 'go' ? '/zen/go/v1/models' : '/zen/v1/models';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+export function parseOpenCodeCatalog(payload: unknown): ModelConfig[] {
+  if (
+    !isRecord(payload) ||
+    payload['object'] !== 'list' ||
+    !Array.isArray(payload['data'])
+  ) {
+    throw new Error(
+      'Invalid OpenCode model catalog: expected an OpenAI list response.',
+    );
+  }
+
+  return payload['data'].map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(
+        `Invalid OpenCode model catalog entry at index ${index}: expected an object.`,
+      );
+    }
+
+    const id = entry['id'];
+    if (typeof id !== 'string' || id.trim() === '') {
+      throw new Error(
+        `Invalid OpenCode model catalog entry at index ${index}: expected a model ID.`,
+      );
+    }
+
+    const name = entry['name'];
+    return {
+      id: id.trim(),
+      ...(typeof name === 'string' && name.trim()
+        ? { name: name.trim() }
+        : {}),
+    };
+  });
+}
+
+function buildHeaders(
+  provider: ProviderConfig,
+  credential: AuthTokenInfo,
+): Record<string, string> {
+  const token = getToken(credential);
+  const headers = mergeHeaders(token, provider.extraHeaders);
+  setUserAgentHeader(headers, getUnifiedUserAgent());
+
+  if (token) {
+    headers['Authorization'] = `${getTokenType(credential) ?? 'Bearer'} ${token}`;
+  }
+  return headers;
+}
+
+export async function fetchOpenCodeCatalog(
+  provider: ProviderConfig,
+  credential: AuthTokenInfo,
+  signal?: AbortSignal,
+  fetcher?: OpenCodeCatalogFetch,
+): Promise<ModelConfig[]> {
+  const url = getOpenCodeCatalogUrl(provider);
+  if (!url) {
+    throw new Error('Provider is not an OpenCode catalog endpoint.');
+  }
+
+  const logger = createSimpleHttpLogger({
+    purpose: 'Get Available Models',
+    providerName: provider.name,
+    providerType: provider.type,
+  });
+  const executeFetch =
+    fetcher ??
+    createCustomFetch({
+      connectionTimeoutMs: DEFAULT_NORMAL_TIMEOUT_CONFIG.connection,
+      responseTimeoutMs: DEFAULT_NORMAL_TIMEOUT_CONFIG.response,
+      logger,
+      proxy: resolveChatNetwork(provider).proxy,
+      type: 'normal',
+      abortSignal: signal,
+    });
+
+  try {
+    const response = await executeFetch(url, {
+      method: 'GET',
+      headers: buildHeaders(provider, credential),
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to get OpenCode model catalog: HTTP ${response.status}.`,
+      );
+    }
+
+    const payload: unknown = await response.json();
+    return parseOpenCodeCatalog(payload);
+  } catch (error) {
+    logger.error(error);
+    throw error;
+  }
+}

--- a/src/well-known/opencode-models.ts
+++ b/src/well-known/opencode-models.ts
@@ -122,7 +122,9 @@ const PROTOCOL_OVERRIDES: Readonly<
   go: GO_PROTOCOL_OVERRIDES,
 };
 
-function getOpenCodeService(baseUrl: string): OpenCodeService | undefined {
+export function getOpenCodeService(
+  baseUrl: string,
+): OpenCodeService | undefined {
   let url: URL;
   try {
     url = new URL(baseUrl);

--- a/src/well-known/opencode-models.ts
+++ b/src/well-known/opencode-models.ts
@@ -9,6 +9,23 @@ export type OpenCodeModelProtocol =
   | 'messages'
   | 'google';
 
+type ProtocolSet = readonly OpenCodeModelProtocol[];
+
+/**
+ * Revision of the models.dev-backed protocol table below. The table was
+ * verified on 2026-08-23 and includes the 2026-08-16 Go Qwen correction.
+ */
+export const OPENCODE_PROTOCOL_RULES_REVISION = 20260823;
+
+const CHAT_COMPLETIONS = ['chat-completions'] as const;
+const RESPONSES = ['responses'] as const;
+const MESSAGES = ['messages'] as const;
+const GOOGLE = ['google'] as const;
+const CHAT_COMPLETIONS_AND_MESSAGES = [
+  'chat-completions',
+  'messages',
+] as const;
+
 const PROVIDER_PROTOCOLS: Partial<
   Record<ProviderConfig['type'], OpenCodeModelProtocol>
 > = {
@@ -16,6 +33,93 @@ const PROVIDER_PROTOCOLS: Partial<
   'openai-responses': 'responses',
   anthropic: 'messages',
   'google-ai-studio': 'google',
+};
+
+/*
+ * OpenCode's provider-level runtime is OpenAI-compatible. Only exact model
+ * overrides from models.dev belong here. Do not infer protocol from a model
+ * family: Go Qwen models demonstrate that the same family can use different
+ * protocols across services and releases.
+ */
+const ZEN_PROTOCOL_OVERRIDES: ReadonlyMap<string, ProtocolSet> = new Map<
+  string,
+  ProtocolSet
+>([
+  ['gpt-5-nano', RESPONSES],
+  ['gpt-5.5-pro', RESPONSES],
+  ['gpt-5.6-sol', RESPONSES],
+  ['grok-4.6', RESPONSES],
+  ['gpt-5.4-pro', RESPONSES],
+  ['grok-4.5', RESPONSES],
+  ['gpt-5', RESPONSES],
+  ['gpt-5.1-codex-mini', RESPONSES],
+  ['gpt-5-codex', RESPONSES],
+  ['gpt-5.6-luna', RESPONSES],
+  ['gpt-5.3-codex', RESPONSES],
+  ['gpt-5.3-codex-spark', RESPONSES],
+  ['muse-spark-1.2-contributor-free', RESPONSES],
+  ['gpt-5.2', RESPONSES],
+  ['gpt-5.4-mini', RESPONSES],
+  ['muse-spark-1.2', RESPONSES],
+  ['gpt-5.5', RESPONSES],
+  ['gpt-5.2-codex', RESPONSES],
+  ['gpt-5.6-terra', RESPONSES],
+  ['gpt-5.4', RESPONSES],
+  ['gpt-5.1-codex-max', RESPONSES],
+  ['gpt-5.1-codex', RESPONSES],
+  ['grok-build-0.1', RESPONSES],
+  ['gpt-5.4-nano', RESPONSES],
+  ['gpt-5.1', RESPONSES],
+  ['claude-opus-4-7', MESSAGES],
+  ['minimax-m3-free', MESSAGES],
+  ['claude-opus-4-8', MESSAGES],
+  ['claude-opus-4-1', MESSAGES],
+  ['claude-sonnet-5', MESSAGES],
+  ['qwen3.5-plus', MESSAGES],
+  ['claude-3-5-haiku', MESSAGES],
+  ['claude-sonnet-4', MESSAGES],
+  ['claude-opus-4-5', MESSAGES],
+  ['claude-sonnet-4-6', MESSAGES],
+  ['minimax-m2.5-free', MESSAGES],
+  ['claude-sonnet-4-5', MESSAGES],
+  ['qwen3.6-plus-free', MESSAGES],
+  ['minimax-m2.1-free', MESSAGES],
+  ['qwen3.6-plus', MESSAGES],
+  ['claude-fable-5', MESSAGES],
+  ['claude-haiku-4-5', MESSAGES],
+  ['claude-opus-4-6', MESSAGES],
+  ['claude-opus-5', MESSAGES],
+  ['gemini-3-pro', GOOGLE],
+  ['gemini-3.5-flash-lite', GOOGLE],
+  ['gemini-3.1-pro', GOOGLE],
+  ['gemini-3.5-flash', GOOGLE],
+  ['gemini-3.6-flash', GOOGLE],
+  ['gemini-3-flash', GOOGLE],
+  ['gemini-3.7-flash', GOOGLE],
+]);
+
+const GO_PROTOCOL_OVERRIDES: ReadonlyMap<string, ProtocolSet> = new Map<
+  string,
+  ProtocolSet
+>([
+  ['grok-4.5', RESPONSES],
+  ['gpt-5.6-luna', RESPONSES],
+  ['muse-spark-1.2-contributor', RESPONSES],
+  ['minimax-m3', MESSAGES],
+  ['minimax-m2.7', MESSAGES],
+  ['minimax-m2.5', MESSAGES],
+  ['qwen3.5-plus', CHAT_COMPLETIONS_AND_MESSAGES],
+  ['qwen3.6-plus', CHAT_COMPLETIONS_AND_MESSAGES],
+  ['qwen3.7-max', CHAT_COMPLETIONS_AND_MESSAGES],
+  ['qwen3.7-plus', CHAT_COMPLETIONS_AND_MESSAGES],
+  ['qwen3.8-max', CHAT_COMPLETIONS_AND_MESSAGES],
+]);
+
+const PROTOCOL_OVERRIDES: Readonly<
+  Record<OpenCodeService, ReadonlyMap<string, ProtocolSet>>
+> = {
+  zen: ZEN_PROTOCOL_OVERRIDES,
+  go: GO_PROTOCOL_OVERRIDES,
 };
 
 function getOpenCodeService(baseUrl: string): OpenCodeService | undefined {
@@ -40,25 +144,12 @@ function getOpenCodeService(baseUrl: string): OpenCodeService | undefined {
   return undefined;
 }
 
-function classifyOpenCodeModel(
+function getOpenCodeModelProtocols(
   modelId: string,
   service: OpenCodeService,
-): OpenCodeModelProtocol {
+): ProtocolSet {
   const id = modelId.trim().toLowerCase();
-
-  if (/^(?:gpt|grok|muse)-/.test(id)) {
-    return 'responses';
-  }
-  if (/^(?:claude|qwen)/.test(id)) {
-    return 'messages';
-  }
-  if (service === 'go' && id.startsWith('minimax-')) {
-    return 'messages';
-  }
-  if (service === 'zen' && id.startsWith('gemini-')) {
-    return 'google';
-  }
-  return 'chat-completions';
+  return PROTOCOL_OVERRIDES[service].get(id) ?? CHAT_COMPLETIONS;
 }
 
 function addFreeTierLabel(model: ModelConfig): ModelConfig {
@@ -86,9 +177,10 @@ export function prepareOfficialModels(
   const providerProtocol = PROVIDER_PROTOCOLS[provider.type];
   const selectedModels =
     service && providerProtocol
-      ? rawModels.filter(
-          (model) =>
-            classifyOpenCodeModel(model.id, service) === providerProtocol,
+      ? rawModels.filter((model) =>
+          getOpenCodeModelProtocols(model.id, service).includes(
+            providerProtocol,
+          ),
         )
       : rawModels;
   const mergedModels = mergeWithWellKnownModels(selectedModels, provider);

--- a/src/well-known/opencode-models.ts
+++ b/src/well-known/opencode-models.ts
@@ -1,0 +1,97 @@
+import type { ModelConfig, ProviderConfig } from '../types';
+import { mergeWithWellKnownModels } from './models';
+
+type OpenCodeService = 'zen' | 'go';
+
+export type OpenCodeModelProtocol =
+  | 'chat-completions'
+  | 'responses'
+  | 'messages'
+  | 'google';
+
+const PROVIDER_PROTOCOLS: Partial<
+  Record<ProviderConfig['type'], OpenCodeModelProtocol>
+> = {
+  'openai-chat-completion': 'chat-completions',
+  'openai-responses': 'responses',
+  anthropic: 'messages',
+  'google-ai-studio': 'google',
+};
+
+function getOpenCodeService(baseUrl: string): OpenCodeService | undefined {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (url.hostname.toLowerCase() !== 'opencode.ai') {
+    return undefined;
+  }
+
+  const path = url.pathname.toLowerCase().replace(/\/+$/, '');
+  if (path === '/zen/go' || path.startsWith('/zen/go/')) {
+    return 'go';
+  }
+  if (path === '/zen' || path.startsWith('/zen/')) {
+    return 'zen';
+  }
+  return undefined;
+}
+
+function classifyOpenCodeModel(
+  modelId: string,
+  service: OpenCodeService,
+): OpenCodeModelProtocol {
+  const id = modelId.trim().toLowerCase();
+
+  if (/^(?:gpt|grok|muse)-/.test(id)) {
+    return 'responses';
+  }
+  if (/^(?:claude|qwen)/.test(id)) {
+    return 'messages';
+  }
+  if (service === 'go' && id.startsWith('minimax-')) {
+    return 'messages';
+  }
+  if (service === 'zen' && id.startsWith('gemini-')) {
+    return 'google';
+  }
+  return 'chat-completions';
+}
+
+function addFreeTierLabel(model: ModelConfig): ModelConfig {
+  if (!model.id.toLowerCase().endsWith('-free') || !model.name) {
+    return model;
+  }
+
+  const name = model.name.trim();
+  if (!name || /\bfree\b/i.test(name)) {
+    return model;
+  }
+  return { ...model, name: `${name} (Free)` };
+}
+
+/**
+ * OpenCode exposes one combined `/models` catalog for all wire protocols.
+ * Select the models compatible with the configured provider before enriching
+ * them with the shared well-known metadata.
+ */
+export function prepareOfficialModels(
+  rawModels: ModelConfig[],
+  provider: ProviderConfig,
+): ModelConfig[] {
+  const service = getOpenCodeService(provider.baseUrl);
+  const providerProtocol = PROVIDER_PROTOCOLS[provider.type];
+  const selectedModels =
+    service && providerProtocol
+      ? rawModels.filter(
+          (model) =>
+            classifyOpenCodeModel(model.id, service) === providerProtocol,
+        )
+      : rawModels;
+  const mergedModels = mergeWithWellKnownModels(selectedModels, provider);
+
+  return service ? mergedModels.map(addFreeTierLabel) : mergedModels;
+}

--- a/test/unit/main-instance-compatibility.test.ts
+++ b/test/unit/main-instance-compatibility.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const network = vi.hoisted(() => ({
-  welcomeCompatibilityVersion: 7,
+  welcomeCompatibilityVersion: 8,
   welcomeExtensionVersion: 'leader-1.0.0',
   writes: [] as string[],
 }));
@@ -142,7 +142,7 @@ import {
 const coordinators: MainInstanceCoordinator[] = [];
 
 beforeEach(() => {
-  network.welcomeCompatibilityVersion = 7;
+  network.welcomeCompatibilityVersion = 8;
   network.welcomeExtensionVersion = 'leader-1.0.0';
   network.writes = [];
 });
@@ -227,7 +227,7 @@ function hello(
 }
 
 describe('main-instance compatibility handshake', () => {
-  it('accepts a differently-versioned v7 follower at a v7 leader', () => {
+  it('accepts a differently-versioned v8 follower at a v8 leader', () => {
     const coordinator = createCoordinator();
     Reflect.set(coordinator, 'authToken', 'test-token');
     const peer = createLeaderSocket();
@@ -242,18 +242,18 @@ describe('main-instance compatibility handshake', () => {
     expect(response).toMatchObject({
       type: 'welcome',
       protocolVersion: 1,
-      mainInstanceCompatibilityVersion: 7,
+      mainInstanceCompatibilityVersion: 8,
     });
   });
 
-  it('rejects a v6 follower at a v7 leader', () => {
+  it('rejects a v7 follower at a v8 leader', () => {
     const coordinator = createCoordinator();
     Reflect.set(coordinator, 'authToken', 'test-token');
     const peer = createLeaderSocket();
 
     invokePrivate(coordinator, 'handleLeaderSideMessage', [
       peer.socket,
-      hello(6),
+      hello(7),
     ]);
 
     expect(peer.isDestroyed()).toBe(true);
@@ -266,7 +266,7 @@ describe('main-instance compatibility handshake', () => {
     });
   });
 
-  it('connects differently-versioned v7 follower and leader releases', async () => {
+  it('connects differently-versioned v8 follower and leader releases', async () => {
     const coordinator = createCoordinator();
     configureFollower(coordinator);
 
@@ -286,12 +286,12 @@ describe('main-instance compatibility handshake', () => {
     expect(parseMessageLine(network.writes[0] ?? '')).toMatchObject({
       type: 'hello',
       extensionVersion: 'follower-9.9.9',
-      mainInstanceCompatibilityVersion: 7,
+      mainInstanceCompatibilityVersion: 8,
     });
   });
 
-  it('rejects a v6 leader at a v7 follower', async () => {
-    network.welcomeCompatibilityVersion = 6;
+  it('rejects a v7 leader at a v8 follower', async () => {
+    network.welcomeCompatibilityVersion = 7;
     const coordinator = createCoordinator();
     configureFollower(coordinator);
 

--- a/test/unit/main-instance-completion-config.test.ts
+++ b/test/unit/main-instance-completion-config.test.ts
@@ -67,6 +67,7 @@ const METHOD = 'config.syncPersistedProvider';
 
 describe('main-instance completion configuration sync', () => {
   const officialState = {
+    modelsProcessingRevision: 20260823,
     lastFetchTime: 1,
     models: [{ id: 'cloud-model' }],
     modelsHash: 'hash',
@@ -81,6 +82,20 @@ describe('main-instance completion configuration sync', () => {
         'officialModels.applyProviderState',
       ),
     ).toEqual(officialState);
+  });
+
+  it('requires the model processing revision in shared official model state', () => {
+    expect(() =>
+      parseOfficialModelsFetchState(
+        { ...officialState, modelsProcessingRevision: undefined },
+        'officialModels.applyProviderState',
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining('modelsProcessingRevision'),
+      }),
+    );
   });
 
   it('strictly parses local auth commit guards', () => {
@@ -354,8 +369,8 @@ describe('main-instance completion configuration sync', () => {
     expect(provider.models[0].completion).toEqual({});
   });
 
-  it('uses compatibility version 7 without changing protocol version 1', () => {
-    expect(MAIN_INSTANCE_COMPATIBILITY_VERSION).toBe(7);
+  it('uses compatibility version 8 without changing protocol version 1', () => {
+    expect(MAIN_INSTANCE_COMPATIBILITY_VERSION).toBe(8);
     expect(PROTOCOL_VERSION).toBe(1);
   });
 

--- a/test/unit/official-models-manager.test.ts
+++ b/test/unit/official-models-manager.test.ts
@@ -51,6 +51,10 @@ vi.mock('../../src/client/utils', () => ({
   createProvider: () => ({
     getAvailableModels: providerClient.getAvailableModels,
   }),
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
 }));
 
 vi.mock('../../src/utils', () => ({
@@ -208,6 +212,38 @@ describe('official model manager provider boundary', () => {
     expect(Object.hasOwn(persisted?.[config.name] ?? {}, 'zedRoutes')).toBe(
       false,
     );
+    manager.dispose();
+  });
+
+  it('persists only models compatible with an OpenCode provider protocol', async () => {
+    providerClient.getAvailableModels.mockResolvedValue([
+      { id: 'gpt-5.6-sol' },
+      { id: 'claude-sonnet-5' },
+      { id: 'deepseek-v4-flash-free' },
+    ]);
+    const config: ProviderConfig = {
+      ...provider(),
+      type: 'openai-chat-completion',
+      name: 'OpenCode Zen (OpenAI Chat Completion)',
+      baseUrl: 'https://opencode.ai/zen',
+    };
+    const manager = new OfficialModelsManager();
+    await manager.initialize(
+      context(new Map()),
+      configStore(config),
+      secretStore(),
+      authManager(),
+    );
+
+    const models = await manager.getOfficialModels(config, true);
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'deepseek-v4-flash-free',
+        name: 'DeepSeek V4 Flash (Free)',
+      }),
+    ]);
+    expect(manager.getProviderState(config.name)?.models).toEqual(models);
     manager.dispose();
   });
 

--- a/test/unit/official-models-manager.test.ts
+++ b/test/unit/official-models-manager.test.ts
@@ -4,6 +4,14 @@ const providerClient = vi.hoisted(() => ({
   getAvailableModels: vi.fn(),
 }));
 
+const providerFactory = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+const openCodeCatalog = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}));
+
 vi.mock('vscode', () => {
   class Disposable {
     constructor(private readonly callback: () => void = () => undefined) {}
@@ -48,13 +56,17 @@ vi.mock('../../src/main-instance', () => ({
 }));
 
 vi.mock('../../src/client/utils', () => ({
-  createProvider: () => ({
-    getAvailableModels: providerClient.getAvailableModels,
-  }),
+  createProvider: providerFactory.create,
   matchProvider: (url: string, pattern: string | RegExp) =>
     typeof pattern === 'string'
       ? url.includes(pattern.replaceAll('*', ''))
       : pattern.test(url),
+}));
+
+vi.mock('../../src/well-known/opencode-catalog', () => ({
+  fetchOpenCodeCatalog: openCodeCatalog.fetch,
+  isOpenCodeCatalogProvider: (provider: ProviderConfig) =>
+    provider.baseUrl.startsWith('https://opencode.ai/zen'),
 }));
 
 vi.mock('../../src/utils', () => ({
@@ -175,6 +187,14 @@ function secretStore(): SecretStore {
 
 beforeEach(() => {
   providerClient.getAvailableModels.mockReset();
+  providerFactory.create.mockReset();
+  providerFactory.create.mockReturnValue({
+    getAvailableModels: providerClient.getAvailableModels,
+  });
+  openCodeCatalog.fetch.mockReset();
+  openCodeCatalog.fetch.mockImplementation(() =>
+    providerClient.getAvailableModels(),
+  );
 });
 
 describe('official model manager provider boundary', () => {
@@ -244,7 +264,52 @@ describe('official model manager provider boundary', () => {
         name: 'DeepSeek V4 Flash (Free)',
       }),
     ]);
+    expect(openCodeCatalog.fetch).toHaveBeenCalledOnce();
+    expect(providerFactory.create).not.toHaveBeenCalled();
     expect(manager.getProviderState(config.name)?.models).toEqual(models);
+    manager.dispose();
+  });
+
+  it('uses the unified OpenCode catalog before filtering Gemini models', async () => {
+    providerClient.getAvailableModels.mockResolvedValue([
+      { id: 'gemini-3-flash' },
+      { id: 'gemini-3.1-pro' },
+      { id: 'gemini-3.5-flash' },
+      { id: 'gemini-3.5-flash-lite' },
+      { id: 'gemini-3.6-flash' },
+      { id: 'gemini-3.7-flash' },
+      { id: 'gpt-5.6-sol' },
+    ]);
+    const config: ProviderConfig = {
+      ...provider(),
+      type: 'google-ai-studio',
+      name: 'OpenCode Zen (Gemini)',
+      baseUrl: 'https://opencode.ai/zen',
+    };
+    const manager = new OfficialModelsManager();
+    await manager.initialize(
+      context(new Map()),
+      configStore(config),
+      secretStore(),
+      authManager(),
+    );
+
+    const models = await manager.getOfficialModels(config, true);
+
+    expect(models.map((model) => model.id)).toEqual([
+      'gemini-3-flash',
+      'gemini-3.1-pro',
+      'gemini-3.5-flash',
+      'gemini-3.5-flash-lite',
+      'gemini-3.6-flash',
+      'gemini-3.7-flash',
+    ]);
+    expect(openCodeCatalog.fetch).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ kind: 'token', token: 'llm-token' }),
+      expect.any(AbortSignal),
+    );
+    expect(providerFactory.create).not.toHaveBeenCalled();
     manager.dispose();
   });
 

--- a/test/unit/official-models-manager.test.ts
+++ b/test/unit/official-models-manager.test.ts
@@ -75,6 +75,7 @@ vi.mock('../../src/auth', () => ({
 
 import type * as vscode from 'vscode';
 import {
+  OFFICIAL_MODELS_PROCESSING_REVISION,
   OfficialModelsManager,
   type OfficialModelsAuthManager,
   type OfficialModelsConfigStore,
@@ -244,6 +245,68 @@ describe('official model manager provider boundary', () => {
       }),
     ]);
     expect(manager.getProviderState(config.name)?.models).toEqual(models);
+    manager.dispose();
+  });
+
+  it('invalidates pre-revision caches before serving or refreshing them', async () => {
+    providerClient.getAvailableModels.mockResolvedValue([
+      { id: 'gpt-5.6-sol' },
+      { id: 'claude-sonnet-5' },
+      { id: 'deepseek-v4-flash-free' },
+    ]);
+    const config: ProviderConfig = {
+      ...provider(),
+      type: 'openai-chat-completion',
+      name: 'OpenCode Zen (OpenAI Chat Completion)',
+      baseUrl: 'https://opencode.ai/zen',
+    };
+    const staleState = {
+      lastFetchTime: Date.now(),
+      lastAttemptTime: Date.now(),
+      models: [
+        { id: 'gpt-5.6-sol' },
+        { id: 'claude-sonnet-5' },
+        { id: 'deepseek-v4-flash-free', name: 'DeepSeek V4 Flash' },
+      ],
+      modelsHash: 'pre-processing-revision',
+      consecutiveIdenticalFetches: 5,
+      currentIntervalMs: 24 * 60 * 60 * 1000,
+    };
+    const storage = new Map<string, unknown>([
+      ['officialModelsState', { [config.name]: staleState }],
+    ]);
+    const manager = new OfficialModelsManager();
+
+    await manager.initialize(
+      context(storage),
+      configStore(config),
+      secretStore(),
+      authManager(),
+    );
+
+    expect(manager.getProviderState(config.name)).toMatchObject({
+      modelsProcessingRevision: OFFICIAL_MODELS_PROCESSING_REVISION,
+      lastFetchTime: 0,
+      lastAttemptTime: 0,
+      models: [],
+      modelsHash: '',
+    });
+    const migrated = storage.get('officialModelsState') as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(migrated[config.name]).toMatchObject({
+      modelsProcessingRevision: OFFICIAL_MODELS_PROCESSING_REVISION,
+      models: [],
+    });
+
+    await expect(manager.getOfficialModels(config)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'deepseek-v4-flash-free',
+        name: 'DeepSeek V4 Flash (Free)',
+      }),
+    ]);
+    expect(providerClient.getAvailableModels).toHaveBeenCalledOnce();
     manager.dispose();
   });
 

--- a/test/unit/opencode-catalog.test.ts
+++ b/test/unit/opencode-catalog.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const httpLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  Disposable: class Disposable {
+    constructor(private readonly callback: () => void = () => undefined) {}
+    dispose(): void {
+      this.callback();
+    }
+  },
+  EventEmitter: class EventEmitter<T> {
+    private readonly listeners = new Set<(value: T) => void>();
+    readonly event = (listener: (value: T) => void) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    };
+    fire(value: T): void {
+      for (const listener of this.listeners) listener(value);
+    }
+    dispose(): void {
+      this.listeners.clear();
+    }
+  },
+  env: { language: 'en' },
+  extensions: { getExtension: () => undefined },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: <T>(_key: string, fallback: T) => fallback,
+    }),
+  },
+}));
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => httpLogger,
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  createCustomFetch: () => {
+    throw new Error('The injected test fetcher should be used.');
+  },
+  getToken: (credential: { kind: string; token?: string }) =>
+    credential.kind === 'token' ? credential.token : undefined,
+  getTokenType: (credential: { kind: string; tokenType?: string }) =>
+    credential.kind === 'token' ? credential.tokenType : undefined,
+  getUnifiedUserAgent: () => 'ucp/test',
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+  mergeHeaders: (
+    token: string | undefined,
+    ...sources: Array<Record<string, string> | undefined>
+  ) => {
+    const headers: Record<string, string> = Object.assign(
+      {},
+      ...sources.filter(Boolean),
+    );
+    for (const [key, value] of Object.entries(headers)) {
+      headers[key] = value.replaceAll('${APIKEY}', token ?? '${APIKEY}');
+    }
+    return headers;
+  },
+  setUserAgentHeader: (headers: Record<string, string>, userAgent: string) => {
+    headers['User-Agent'] = userAgent;
+  },
+}));
+
+vi.mock('../../src/utils', () => ({
+  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
+    connection: 20_000,
+    response: 120_000,
+  },
+  resolveChatNetwork: () => ({ proxy: undefined }),
+}));
+
+import {
+  fetchOpenCodeCatalog,
+  getOpenCodeCatalogUrl,
+  type OpenCodeCatalogFetch,
+  parseOpenCodeCatalog,
+} from '../../src/well-known/opencode-catalog';
+import { prepareOfficialModels } from '../../src/well-known/opencode-models';
+import type { ProviderConfig } from '../../src/types';
+
+const geminiIds = [
+  'gemini-3-flash',
+  'gemini-3.1-pro',
+  'gemini-3.5-flash',
+  'gemini-3.5-flash-lite',
+  'gemini-3.6-flash',
+  'gemini-3.7-flash',
+] as const;
+
+function geminiProvider(): ProviderConfig {
+  return {
+    type: 'google-ai-studio',
+    name: 'OpenCode Zen (Gemini)',
+    baseUrl: 'https://opencode.ai/zen',
+    models: [],
+  };
+}
+
+beforeEach(() => {
+  httpLogger.error.mockReset();
+});
+
+describe('OpenCode model catalog transport', () => {
+  it('uses canonical catalog URLs for both OpenCode services', () => {
+    expect(getOpenCodeCatalogUrl(geminiProvider())).toBe(
+      'https://opencode.ai/zen/v1/models',
+    );
+    expect(
+      getOpenCodeCatalogUrl({
+        ...geminiProvider(),
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+      }),
+    ).toBe('https://opencode.ai/zen/go/v1/models');
+  });
+
+  it('fetches the real Zen catalog URL and delivers six Gemini models', async () => {
+    const fetcher = vi.fn<OpenCodeCatalogFetch>(async (input, init) => {
+      expect(input.toString()).toBe('https://opencode.ai/zen/v1/models');
+      expect(init?.method).toBe('GET');
+      expect(new Headers(init?.headers).get('authorization')).toBe(
+        'Bearer zen-key',
+      );
+
+      return new Response(
+        JSON.stringify({
+          object: 'list',
+          data: [
+            ...geminiIds.map((id) => ({
+              id,
+              object: 'model',
+              owned_by: 'opencode',
+            })),
+            {
+              id: 'gpt-5.6-sol',
+              object: 'model',
+              owned_by: 'opencode',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    const provider = geminiProvider();
+
+    const rawModels = await fetchOpenCodeCatalog(
+      provider,
+      { kind: 'token', token: 'zen-key' },
+      undefined,
+      fetcher,
+    );
+    const models = prepareOfficialModels(rawModels, provider);
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(models.map((model) => model.id)).toEqual(geminiIds);
+  });
+
+  it('rejects a Google-shaped response instead of silently returning no models', () => {
+    expect(() =>
+      parseOpenCodeCatalog({
+        models: geminiIds.map((name) => ({ name })),
+      }),
+    ).toThrowError('expected an OpenAI list response');
+  });
+});

--- a/test/unit/opencode-models.test.ts
+++ b/test/unit/opencode-models.test.ts
@@ -15,7 +15,10 @@ vi.mock('../../src/client/utils', () => ({
       : pattern.test(url),
 }));
 
-import { prepareOfficialModels } from '../../src/well-known/opencode-models';
+import {
+  OPENCODE_PROTOCOL_RULES_REVISION,
+  prepareOfficialModels,
+} from '../../src/well-known/opencode-models';
 import type { ModelConfig, ProviderConfig } from '../../src/types';
 
 type OpenCodeProviderType =
@@ -46,9 +49,10 @@ describe('OpenCode official model aggregation', () => {
     { id: 'grok-4.5' },
     { id: 'muse-spark-1.2' },
     { id: 'claude-sonnet-5' },
-    { id: 'qwen3.7-plus' },
+    { id: 'qwen3.6-plus' },
     { id: 'gemini-3.7-flash' },
     { id: 'minimax-m3' },
+    { id: 'minimax-m3-free' },
     { id: 'deepseek-v4-flash' },
     { id: 'deepseek-v4-flash-free' },
   ];
@@ -64,7 +68,10 @@ describe('OpenCode official model aggregation', () => {
         ],
       ],
       ['openai-responses', ['gpt-5.6-sol', 'grok-4.5', 'muse-spark-1.2']],
-      ['anthropic', ['claude-sonnet-5', 'qwen3.7-plus']],
+      [
+        'anthropic',
+        ['claude-sonnet-5', 'qwen3.6-plus', 'minimax-m3-free'],
+      ],
       ['google-ai-studio', ['gemini-3.7-flash']],
     ]);
 
@@ -82,13 +89,17 @@ describe('OpenCode official model aggregation', () => {
     );
   });
 
-  it('uses Go-specific Messages routing for MiniMax and Qwen models', () => {
+  it('keeps documented Go Qwen models in both supported protocols', () => {
     const goCatalog: ModelConfig[] = [
       { id: 'gpt-5.6-luna' },
       { id: 'grok-4.5' },
       { id: 'muse-spark-1.2-contributor' },
       { id: 'minimax-m3' },
       { id: 'minimax-m2.7' },
+      { id: 'qwen3.5-plus' },
+      { id: 'qwen3.6-plus' },
+      { id: 'qwen3.7-max' },
+      { id: 'qwen3.7-plus' },
       { id: 'qwen3.8-max' },
       { id: 'deepseek-v4-pro' },
       { id: 'glm-5.3' },
@@ -102,10 +113,26 @@ describe('OpenCode official model aggregation', () => {
           provider('openai-chat-completion', baseUrl),
         ),
       ),
-    ).toEqual(['deepseek-v4-pro', 'glm-5.3']);
+    ).toEqual([
+      'qwen3.5-plus',
+      'qwen3.6-plus',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'qwen3.8-max',
+      'deepseek-v4-pro',
+      'glm-5.3',
+    ]);
     expect(
       ids(prepareOfficialModels(goCatalog, provider('anthropic', baseUrl))),
-    ).toEqual(['minimax-m3', 'minimax-m2.7', 'qwen3.8-max']);
+    ).toEqual([
+      'minimax-m3',
+      'minimax-m2.7',
+      'qwen3.5-plus',
+      'qwen3.6-plus',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'qwen3.8-max',
+    ]);
     expect(
       ids(
         prepareOfficialModels(
@@ -114,6 +141,29 @@ describe('OpenCode official model aggregation', () => {
         ),
       ),
     ).toEqual(['gpt-5.6-luna', 'grok-4.5', 'muse-spark-1.2-contributor']);
+  });
+
+  it('uses the service default for unknown IDs instead of family prefixes', () => {
+    const unknownCatalog: ModelConfig[] = [
+      { id: 'qwen-future' },
+      { id: 'claude-future' },
+    ];
+
+    expect(
+      ids(
+        prepareOfficialModels(
+          unknownCatalog,
+          provider('openai-chat-completion'),
+        ),
+      ),
+    ).toEqual(['qwen-future', 'claude-future']);
+    expect(
+      ids(prepareOfficialModels(unknownCatalog, provider('anthropic'))),
+    ).toEqual([]);
+  });
+
+  it('exposes the protocol table revision used by persisted cache state', () => {
+    expect(OPENCODE_PROTOCOL_RULES_REVISION).toBe(20260823);
   });
 
   it('marks a matched free variant without changing its API model ID', () => {

--- a/test/unit/opencode-models.test.ts
+++ b/test/unit/opencode-models.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+}));
+
+import { prepareOfficialModels } from '../../src/well-known/opencode-models';
+import type { ModelConfig, ProviderConfig } from '../../src/types';
+
+type OpenCodeProviderType =
+  | 'openai-chat-completion'
+  | 'openai-responses'
+  | 'anthropic'
+  | 'google-ai-studio';
+
+function provider(
+  type: OpenCodeProviderType,
+  baseUrl = 'https://opencode.ai/zen',
+): ProviderConfig {
+  return {
+    type,
+    name: `OpenCode ${type}`,
+    baseUrl,
+    models: [],
+  };
+}
+
+function ids(models: ModelConfig[]): string[] {
+  return models.map((model) => model.id);
+}
+
+describe('OpenCode official model aggregation', () => {
+  const zenCatalog: ModelConfig[] = [
+    { id: 'gpt-5.6-sol' },
+    { id: 'grok-4.5' },
+    { id: 'muse-spark-1.2' },
+    { id: 'claude-sonnet-5' },
+    { id: 'qwen3.7-plus' },
+    { id: 'gemini-3.7-flash' },
+    { id: 'minimax-m3' },
+    { id: 'deepseek-v4-flash' },
+    { id: 'deepseek-v4-flash-free' },
+  ];
+
+  it('partitions the Zen catalog into disjoint protocol-specific lists', () => {
+    const expected = new Map<OpenCodeProviderType, string[]>([
+      [
+        'openai-chat-completion',
+        [
+          'minimax-m3',
+          'deepseek-v4-flash',
+          'deepseek-v4-flash-free',
+        ],
+      ],
+      ['openai-responses', ['gpt-5.6-sol', 'grok-4.5', 'muse-spark-1.2']],
+      ['anthropic', ['claude-sonnet-5', 'qwen3.7-plus']],
+      ['google-ai-studio', ['gemini-3.7-flash']],
+    ]);
+
+    const occurrences = new Map<string, number>();
+    for (const [type, expectedIds] of expected) {
+      const actualIds = ids(prepareOfficialModels(zenCatalog, provider(type)));
+      expect(actualIds).toEqual(expectedIds);
+      for (const id of actualIds) {
+        occurrences.set(id, (occurrences.get(id) ?? 0) + 1);
+      }
+    }
+
+    expect(Object.fromEntries(occurrences)).toEqual(
+      Object.fromEntries(zenCatalog.map((model) => [model.id, 1])),
+    );
+  });
+
+  it('uses Go-specific Messages routing for MiniMax and Qwen models', () => {
+    const goCatalog: ModelConfig[] = [
+      { id: 'gpt-5.6-luna' },
+      { id: 'grok-4.5' },
+      { id: 'muse-spark-1.2-contributor' },
+      { id: 'minimax-m3' },
+      { id: 'minimax-m2.7' },
+      { id: 'qwen3.8-max' },
+      { id: 'deepseek-v4-pro' },
+      { id: 'glm-5.3' },
+    ];
+    const baseUrl = 'https://opencode.ai/zen/go/v1';
+
+    expect(
+      ids(
+        prepareOfficialModels(
+          goCatalog,
+          provider('openai-chat-completion', baseUrl),
+        ),
+      ),
+    ).toEqual(['deepseek-v4-pro', 'glm-5.3']);
+    expect(
+      ids(prepareOfficialModels(goCatalog, provider('anthropic', baseUrl))),
+    ).toEqual(['minimax-m3', 'minimax-m2.7', 'qwen3.8-max']);
+    expect(
+      ids(
+        prepareOfficialModels(
+          goCatalog,
+          provider('openai-responses', baseUrl),
+        ),
+      ),
+    ).toEqual(['gpt-5.6-luna', 'grok-4.5', 'muse-spark-1.2-contributor']);
+  });
+
+  it('marks a matched free variant without changing its API model ID', () => {
+    const [model] = prepareOfficialModels(
+      [{ id: 'deepseek-v4-flash-free' }],
+      provider('openai-chat-completion'),
+    );
+
+    expect(model).toMatchObject({
+      id: 'deepseek-v4-flash-free',
+      name: 'DeepSeek V4 Flash (Free)',
+    });
+  });
+
+  it('does not apply OpenCode routing to other hosts or paths', () => {
+    for (const baseUrl of [
+      'https://example.com/zen/v1',
+      'https://opencode.ai.example.com/zen/v1',
+      'https://opencode.ai/v1',
+    ]) {
+      expect(
+        ids(
+          prepareOfficialModels(
+            zenCatalog,
+            provider('openai-responses', baseUrl),
+          ),
+        ),
+      ).toEqual(ids(zenCatalog));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fetch every OpenCode catalog through its canonical `/zen[/go]/v1/models` endpoint with a protocol-independent OpenAI `object/list + data[]` parser, instead of using the configured chat protocol SDK
- partition OpenCode's combined `/models` catalogs with an exact, versioned `(service, model ID) -> protocol set` table derived from the runtime models.dev provider metadata
- inherit the OpenAI-compatible service default for IDs without an exact override instead of guessing from model-family prefixes
- preserve Go `qwen3.5-plus`, `qwen3.6-plus`, `qwen3.7-max`, `qwen3.7-plus`, and `qwen3.8-max` in both Chat Completions and Messages because the runtime default and endpoint documentation describe both protocols
- apply the same unified fetch and processing to persisted and draft states, and distinguish `-free` variants without changing API model IDs
- version processed model cache state, invalidate pre-revision caches immediately on upgrade, and bump the independent main-instance compatibility boundary for the changed shared-state contract

## Protocol authority
- Runtime catalog: https://models.dev/api.json (`opencode` and `opencode-go` provider/model `npm` fields)
- Go Qwen runtime correction: https://github.com/anomalyco/models.dev/commit/9d4b5725df2adf1a303059d8635c558b001156d8
- Endpoint documentation: https://opencode.ai/docs/zen/#endpoints and https://opencode.ai/docs/go/#endpoints

The checked-in table was verified against all 93 Zen and 28 Go models in models.dev on 2026-08-23 with zero mapping differences. The five documented Go Qwen models intentionally add Messages to their OpenAI-compatible runtime default.

## Validation
- `npm exec vitest run test/unit/opencode-catalog.test.ts test/unit/opencode-models.test.ts test/unit/official-models-manager.test.ts test/unit/main-instance-completion-config.test.ts test/unit/main-instance-compatibility.test.ts` (5 files, 34 tests passed; includes the real Zen catalog URL, OpenAI response envelope, and all 6 live Gemini IDs)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `npm run test:unit` (105 files and 1,244 tests passed; one pre-existing DeepSeek Vision FIM assertion failed)
- clean `origin/main` at `616a3bd` reproduces the same `test/unit/plan4-provider-catalog.test.ts` failure
- `npm run l10n:check`
- `npm run test:e2e` compiled successfully, but the Extension Host could not be exercised in this environment: VS Code 1.134 renamed the macOS executable while `@vscode/test-electron@3.0.0` still resolves `Electron`; a temporary compatibility symlink reached the launcher, which then remained idle without creating an Extension Host process or logs and was terminated

Fixes #283
