### PR TITLE
fix(antigravity): add Gemini 3.5 and 3.6 Flash routes

### DIFF
--- a/src/client/google/antigravity-client.ts
+++ b/src/client/google/antigravity-client.ts
@@ -5,6 +5,7 @@ import {
   CODE_ASSIST_HEADERS,
 } from '../../auth/providers/antigravity-oauth/constants';
 import {
+  ANTIGRAVITY_AVAILABLE_MODEL_IDS,
   type Gemini3ThinkingLevel,
   GoogleCodeAssistProvider,
   resolveAntigravityModelForRequest,
@@ -45,11 +46,6 @@ export class GoogleAntigravityProvider extends GoogleCodeAssistProvider {
     this.validateAuth();
     // Sync rule: keep canonical model IDs used by this project config.
     // Do NOT copy reference project's "antigravity-*" prefixed IDs directly.
-    return [
-      { id: 'gemini-3.1-pro' },
-      { id: 'gemini-3-flash' },
-      { id: 'claude-sonnet-4-6' },
-      { id: 'claude-opus-4-6' },
-    ];
+    return ANTIGRAVITY_AVAILABLE_MODEL_IDS.map((id) => ({ id }));
   }
 }

--- a/src/client/google/antigravity-model-resolver.ts
+++ b/src/client/google/antigravity-model-resolver.ts
@@ -1,6 +1,7 @@
 export type Gemini3ThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 
 export const ANTIGRAVITY_AVAILABLE_MODEL_IDS = [
+  'gemini-3.7-flash',
   'gemini-3.6-flash',
   'gemini-3.5-flash',
   'gemini-3.1-pro',
@@ -79,6 +80,21 @@ function resolveGemini35FlashRoute(
   }
 }
 
+function resolveKnownGemini35WireModel(
+  modelId: string,
+): Exclude<Gemini3ThinkingLevel, 'minimal'> | undefined {
+  switch (modelId) {
+    case ANTIGRAVITY_GEMINI_3_5_FLASH_LOW_MODEL:
+      return 'low';
+    case ANTIGRAVITY_GEMINI_3_5_FLASH_MEDIUM_MODEL:
+      return 'medium';
+    case ANTIGRAVITY_GEMINI_3_5_FLASH_HIGH_MODEL:
+      return 'high';
+    default:
+      return undefined;
+  }
+}
+
 export function resolveAntigravityModelForRequest(
   modelId: string,
   preferredGemini3ThinkingLevel?: Gemini3ThinkingLevel,
@@ -106,6 +122,16 @@ export function resolveAntigravityModelForRequest(
     return { requestModelId: trimmed };
   }
 
+  // Gemini 3.5 wire IDs do not use canonical effort suffixes. In particular,
+  // `gemini-3.5-flash-low` is the medium route and must not be remapped.
+  const knownGemini35WireLevel = resolveKnownGemini35WireModel(modelLower);
+  if (knownGemini35WireLevel) {
+    return {
+      requestModelId: modelLower,
+      gemini3ThinkingLevel: knownGemini35WireLevel,
+    };
+  }
+
   const { baseModelId, tier } = parseGemini3TierSuffix(trimmed);
   const baseModelLower = baseModelId.toLowerCase();
   const effectiveLevel: Gemini3ThinkingLevel =
@@ -113,7 +139,8 @@ export function resolveAntigravityModelForRequest(
 
   if (
     baseModelLower === 'gemini-3.5-flash' ||
-    baseModelLower === 'gemini-3.6-flash'
+    baseModelLower === 'gemini-3.6-flash' ||
+    baseModelLower === 'gemini-3.7-flash'
   ) {
     const flashThinkingLevel =
       normalizeAntigravityFlashThinkingLevel(effectiveLevel);
@@ -121,7 +148,7 @@ export function resolveAntigravityModelForRequest(
       requestModelId:
         baseModelLower === 'gemini-3.5-flash'
           ? resolveGemini35FlashRoute(flashThinkingLevel)
-          : `gemini-3.6-flash-${flashThinkingLevel}`,
+          : `${baseModelLower}-${flashThinkingLevel}`,
       gemini3ThinkingLevel: flashThinkingLevel,
     };
   }

--- a/src/client/google/antigravity-model-resolver.ts
+++ b/src/client/google/antigravity-model-resolver.ts
@@ -1,5 +1,14 @@
 export type Gemini3ThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 
+export const ANTIGRAVITY_AVAILABLE_MODEL_IDS = [
+  'gemini-3.6-flash',
+  'gemini-3.5-flash',
+  'gemini-3.1-pro',
+  'gemini-3-flash',
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
+] as const;
+
 const IMAGE_MODEL_PATTERN = /image|imagen/i;
 const GEMINI_3_TIER_SUFFIX = /-(minimal|low|medium|high)$/i;
 const GEMINI_3_PRO_PATTERN = /^gemini-3(?:\.\d+)?-pro/i;
@@ -8,6 +17,10 @@ const CLAUDE_THINKING_SUFFIX = /-thinking$/i;
 
 const ANTIGRAVITY_GEMINI_3_1_PRO_AGENT_MODEL = 'gemini-pro-agent';
 const ANTIGRAVITY_GEMINI_3_1_PRO_LOW_MODEL = 'gemini-3.1-pro-low';
+const ANTIGRAVITY_GEMINI_3_5_FLASH_HIGH_MODEL = 'gemini-3-flash-agent';
+const ANTIGRAVITY_GEMINI_3_5_FLASH_LOW_MODEL =
+  'gemini-3.5-flash-extra-low';
+const ANTIGRAVITY_GEMINI_3_5_FLASH_MEDIUM_MODEL = 'gemini-3.5-flash-low';
 
 export function isAntigravityImageModel(modelId: string): boolean {
   return IMAGE_MODEL_PATTERN.test(modelId);
@@ -47,6 +60,25 @@ function resolveGemini31ProRoute(
     : ANTIGRAVITY_GEMINI_3_1_PRO_AGENT_MODEL;
 }
 
+function normalizeAntigravityFlashThinkingLevel(
+  thinkingLevel: Gemini3ThinkingLevel,
+): Exclude<Gemini3ThinkingLevel, 'minimal'> {
+  return thinkingLevel === 'minimal' ? 'low' : thinkingLevel;
+}
+
+function resolveGemini35FlashRoute(
+  thinkingLevel: Exclude<Gemini3ThinkingLevel, 'minimal'>,
+): string {
+  switch (thinkingLevel) {
+    case 'low':
+      return ANTIGRAVITY_GEMINI_3_5_FLASH_LOW_MODEL;
+    case 'medium':
+      return ANTIGRAVITY_GEMINI_3_5_FLASH_MEDIUM_MODEL;
+    case 'high':
+      return ANTIGRAVITY_GEMINI_3_5_FLASH_HIGH_MODEL;
+  }
+}
+
 export function resolveAntigravityModelForRequest(
   modelId: string,
   preferredGemini3ThinkingLevel?: Gemini3ThinkingLevel,
@@ -74,12 +106,28 @@ export function resolveAntigravityModelForRequest(
     return { requestModelId: trimmed };
   }
 
+  const { baseModelId, tier } = parseGemini3TierSuffix(trimmed);
+  const baseModelLower = baseModelId.toLowerCase();
+  const effectiveLevel: Gemini3ThinkingLevel =
+    preferredGemini3ThinkingLevel ?? tier ?? 'high';
+
+  if (
+    baseModelLower === 'gemini-3.5-flash' ||
+    baseModelLower === 'gemini-3.6-flash'
+  ) {
+    const flashThinkingLevel =
+      normalizeAntigravityFlashThinkingLevel(effectiveLevel);
+    return {
+      requestModelId:
+        baseModelLower === 'gemini-3.5-flash'
+          ? resolveGemini35FlashRoute(flashThinkingLevel)
+          : `gemini-3.6-flash-${flashThinkingLevel}`,
+      gemini3ThinkingLevel: flashThinkingLevel,
+    };
+  }
+
   const isGemini3Pro = GEMINI_3_PRO_PATTERN.test(modelLower);
   if (isGemini3Pro) {
-    const { baseModelId, tier } = parseGemini3TierSuffix(trimmed);
-    const effectiveLevel: Gemini3ThinkingLevel =
-      preferredGemini3ThinkingLevel ?? tier ?? 'high';
-
     if (isAntigravityImageModel(baseModelId)) {
       return {
         requestModelId: baseModelId,
@@ -93,8 +141,6 @@ export function resolveAntigravityModelForRequest(
     return { requestModelId, gemini3ThinkingLevel: effectiveLevel };
   }
 
-  const effectiveLevel: Gemini3ThinkingLevel =
-    preferredGemini3ThinkingLevel ?? 'high';
   return {
     requestModelId: trimmed,
     gemini3ThinkingLevel: effectiveLevel,

--- a/src/client/google/code-assist-client.ts
+++ b/src/client/google/code-assist-client.ts
@@ -55,6 +55,7 @@ import {
 } from './antigravity-model-resolver';
 
 export {
+  ANTIGRAVITY_AVAILABLE_MODEL_IDS,
   resolveAntigravityModelForRequest,
   type Gemini3ThinkingLevel,
 } from './antigravity-model-resolver';

--- a/test/unit/antigravity-model-resolver.test.ts
+++ b/test/unit/antigravity-model-resolver.test.ts
@@ -6,10 +6,37 @@ import {
 } from '../../src/client/google/antigravity-model-resolver';
 
 describe('Antigravity model resolver', () => {
-  it('lists the supported Gemini 3.5 and 3.6 Flash models', () => {
+  it('lists the current supported Gemini Flash models newest first', () => {
+    expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS[0]).toBe('gemini-3.7-flash');
     expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS).toContain('gemini-3.5-flash');
     expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS).toContain('gemini-3.6-flash');
+    expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS).toContain('gemini-3.7-flash');
   });
+
+  const gemini37FlashRoutes: Array<
+    [Gemini3ThinkingLevel, string, Gemini3ThinkingLevel]
+  > = [
+    ['minimal', 'gemini-3.7-flash-low', 'low'],
+    ['low', 'gemini-3.7-flash-low', 'low'],
+    ['medium', 'gemini-3.7-flash-medium', 'medium'],
+    ['high', 'gemini-3.7-flash-high', 'high'],
+  ];
+
+  it.each(gemini37FlashRoutes)(
+    'routes Gemini 3.7 Flash %s through %s',
+    (thinkingLevel, requestModelId, resolvedThinkingLevel) => {
+      expect(
+        resolveAntigravityModelForRequest(
+          'gemini-3.7-flash',
+          thinkingLevel,
+          true,
+        ),
+      ).toEqual({
+        requestModelId,
+        gemini3ThinkingLevel: resolvedThinkingLevel,
+      });
+    },
+  );
 
   const gemini36FlashRoutes: Array<
     [Gemini3ThinkingLevel, string, Gemini3ThinkingLevel]
@@ -65,6 +92,29 @@ describe('Antigravity model resolver', () => {
         requestModelId,
         gemini3ThinkingLevel: resolvedThinkingLevel,
       });
+    },
+  );
+
+  it.each([
+    ['gemini-3.5-flash-extra-low', 'low'],
+    ['gemini-3.5-flash-low', 'medium'],
+    ['gemini-3-flash-agent', 'high'],
+  ] as const)(
+    'preserves the Gemini 3.5 wire model %s as the %s route',
+    (requestModelId, gemini3ThinkingLevel) => {
+      const resolved = resolveAntigravityModelForRequest(requestModelId);
+
+      expect(resolved).toEqual({
+        requestModelId,
+        gemini3ThinkingLevel,
+      });
+      expect(
+        resolveAntigravityModelForRequest(
+          resolved.requestModelId,
+          resolved.gemini3ThinkingLevel,
+          true,
+        ),
+      ).toEqual(resolved);
     },
   );
 

--- a/test/unit/antigravity-model-resolver.test.ts
+++ b/test/unit/antigravity-model-resolver.test.ts
@@ -1,10 +1,82 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ANTIGRAVITY_AVAILABLE_MODEL_IDS,
   resolveAntigravityModelForRequest,
   type Gemini3ThinkingLevel,
 } from '../../src/client/google/antigravity-model-resolver';
 
 describe('Antigravity model resolver', () => {
+  it('lists the supported Gemini 3.5 and 3.6 Flash models', () => {
+    expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS).toContain('gemini-3.5-flash');
+    expect(ANTIGRAVITY_AVAILABLE_MODEL_IDS).toContain('gemini-3.6-flash');
+  });
+
+  const gemini36FlashRoutes: Array<
+    [Gemini3ThinkingLevel, string, Gemini3ThinkingLevel]
+  > = [
+    ['minimal', 'gemini-3.6-flash-low', 'low'],
+    ['low', 'gemini-3.6-flash-low', 'low'],
+    ['medium', 'gemini-3.6-flash-medium', 'medium'],
+    ['high', 'gemini-3.6-flash-high', 'high'],
+  ];
+
+  it.each(gemini36FlashRoutes)(
+    'routes Gemini 3.6 Flash %s through %s',
+    (thinkingLevel, requestModelId, resolvedThinkingLevel) => {
+      expect(
+        resolveAntigravityModelForRequest(
+          'gemini-3.6-flash',
+          thinkingLevel,
+          true,
+        ),
+      ).toEqual({
+        requestModelId,
+        gemini3ThinkingLevel: resolvedThinkingLevel,
+      });
+    },
+  );
+
+  it('routes a manually added bare Gemini 3.6 Flash model', () => {
+    expect(resolveAntigravityModelForRequest('gemini-3.6-flash')).toEqual({
+      requestModelId: 'gemini-3.6-flash-high',
+      gemini3ThinkingLevel: 'high',
+    });
+  });
+
+  const gemini35FlashRoutes: Array<
+    [Gemini3ThinkingLevel, string, Gemini3ThinkingLevel]
+  > = [
+    ['minimal', 'gemini-3.5-flash-extra-low', 'low'],
+    ['low', 'gemini-3.5-flash-extra-low', 'low'],
+    ['medium', 'gemini-3.5-flash-low', 'medium'],
+    ['high', 'gemini-3-flash-agent', 'high'],
+  ];
+
+  it.each(gemini35FlashRoutes)(
+    'routes Gemini 3.5 Flash %s through %s',
+    (thinkingLevel, requestModelId, resolvedThinkingLevel) => {
+      expect(
+        resolveAntigravityModelForRequest(
+          'gemini-3.5-flash',
+          thinkingLevel,
+          true,
+        ),
+      ).toEqual({
+        requestModelId,
+        gemini3ThinkingLevel: resolvedThinkingLevel,
+      });
+    },
+  );
+
+  it('uses the routed tier encoded in a Gemini 3.6 model ID', () => {
+    expect(
+      resolveAntigravityModelForRequest('gemini-3.6-flash-medium'),
+    ).toEqual({
+      requestModelId: 'gemini-3.6-flash-medium',
+      gemini3ThinkingLevel: 'medium',
+    });
+  });
+
   const gemini31ProRoutes: Array<[Gemini3ThinkingLevel, string]> = [
     ['high', 'gemini-pro-agent'],
     ['medium', 'gemini-pro-agent'],

--- a/test/unit/antigravity-stream-body.test.ts
+++ b/test/unit/antigravity-stream-body.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const network = vi.hoisted(() => {
+  const bodies: unknown[] = [];
+  const fetcher: typeof fetch = async () =>
+    new Response(JSON.stringify({ response: { candidates: [] } }), {
+      status: 200,
+    });
+  return { bodies, fetcher };
+});
+
+vi.mock('vscode', () => {
+  class LanguageModelTextPart {
+    constructor(readonly value: string) {}
+  }
+  class LanguageModelThinkingPart {
+    constructor(
+      readonly value: string | string[],
+      readonly id?: string,
+      readonly metadata?: Record<string, unknown>,
+    ) {}
+  }
+  class LanguageModelToolCallPart {
+    constructor(
+      readonly callId: string,
+      readonly name: string,
+      readonly input: object,
+    ) {}
+  }
+  class LanguageModelToolResultPart {
+    constructor(
+      readonly callId: string,
+      readonly content: unknown[],
+    ) {}
+  }
+  class LanguageModelDataPart {
+    constructor(
+      readonly data: Uint8Array,
+      readonly mimeType: string,
+    ) {}
+  }
+
+  return {
+    env: { language: 'en' },
+    l10n: { t: (message: string) => message },
+    LanguageModelTextPart,
+    LanguageModelThinkingPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelToolResultPart2: LanguageModelToolResultPart,
+    LanguageModelDataPart,
+    LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelChatToolMode: { Auto: 1, Required: 2 },
+    window: {
+      createOutputChannel: () => ({
+        info: () => undefined,
+        error: () => undefined,
+        warn: () => undefined,
+        debug: () => undefined,
+        trace: () => undefined,
+        append: () => undefined,
+        appendLine: () => undefined,
+        replace: () => undefined,
+        clear: () => undefined,
+        show: () => undefined,
+        hide: () => undefined,
+        dispose: () => undefined,
+        name: 'test',
+        logLevel: 2,
+        onDidChangeLogLevel: () => ({ dispose: () => undefined }),
+      }),
+    },
+    workspace: {
+      getConfiguration: () => ({
+        get: <T>(_key: string, fallback: T) => fallback,
+      }),
+    },
+  };
+});
+
+vi.mock('../../src/config-store', () => ({
+  CONFIG_NAMESPACE: 'unifyChatProvider',
+}));
+
+vi.mock('../../src/official-models-manager', () => ({
+  officialModelsManager: {},
+}));
+
+vi.mock('../../src/client/definitions', () => ({
+  FeatureId: { GeminiUseThinkingLevel: 'gemini_use-thinking-level' },
+}));
+
+vi.mock('../../src/client/utils', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/client/utils')>();
+  return {
+    ...actual,
+    createCustomFetch: () => network.fetcher,
+  };
+});
+
+vi.mock(
+  '../../src/auth/providers/antigravity-oauth/version',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../../src/auth/providers/antigravity-oauth/version')
+      >();
+    return {
+      ...actual,
+      getAntigravityVersion: async () => '1.1.19',
+    };
+  },
+);
+
+import * as vscode from 'vscode';
+import type { AuthTokenInfo } from '../../src/auth/types';
+import { GoogleAntigravityProvider } from '../../src/client/google/antigravity-client';
+import { RequestLogger } from '../../src/logger';
+import type {
+  ChatRequestTrace,
+  ModelConfig,
+  ProviderConfig,
+  ThinkingEffort,
+} from '../../src/types';
+
+const providerConfig: ProviderConfig = {
+  type: 'google-antigravity',
+  name: 'Antigravity',
+  baseUrl: 'https://cloudcode-pa.googleapis.com',
+  models: [],
+  auth: { method: 'antigravity-oauth', bindingId: 'binding' },
+  retry: { maxRetries: 0 },
+};
+
+const credential: AuthTokenInfo = {
+  kind: 'token',
+  token: 'access-token',
+  authContext: {
+    method: 'antigravity-oauth',
+    bindingId: 'binding',
+    sessionId: 'session',
+    revision: 1,
+    projectId: 'test-project',
+  },
+};
+
+function messages(): vscode.LanguageModelChatRequestMessage[] {
+  return [
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new vscode.LanguageModelTextPart('hello')],
+    },
+  ];
+}
+
+function cancellationToken(): vscode.CancellationToken {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose: () => undefined }),
+  };
+}
+
+function trace(): ChatRequestTrace {
+  return {
+    performance: { tts: Date.now(), ttf: 0, ttft: 0, tps: 0, tl: 0 },
+  };
+}
+
+async function collect(source: AsyncIterable<unknown>): Promise<void> {
+  for await (const _value of source) {
+    // Exhaust the request so the captured body is the one sent by streamChat.
+  }
+}
+
+async function captureRequestBody(
+  modelId: string,
+  effort?: ThinkingEffort,
+): Promise<unknown> {
+  const model: ModelConfig = {
+    id: modelId,
+    stream: false,
+    thinking: { type: 'enabled', effort },
+  };
+
+  await collect(
+    new GoogleAntigravityProvider(providerConfig).streamChat(
+      modelId,
+      model,
+      messages(),
+      {
+        requestInitiator: 'test',
+        toolMode: vscode.LanguageModelChatToolMode.Auto,
+        tools: [],
+      },
+      trace(),
+      cancellationToken(),
+      new RequestLogger('antigravity-stream-body-test'),
+      credential,
+    ),
+  );
+
+  return network.bodies.at(-1);
+}
+
+beforeEach(() => {
+  network.bodies.length = 0;
+  network.fetcher = async (_input, init) => {
+    if (typeof init?.body !== 'string') {
+      throw new Error('Expected streamChat to send a JSON request body');
+    }
+    const body: unknown = JSON.parse(init.body);
+    network.bodies.push(body);
+    return new Response(JSON.stringify({ response: { candidates: [] } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+});
+
+describe('Antigravity streamChat request routing', () => {
+  it('sends Gemini 3.7 minimal through the low runtime route', async () => {
+    const body = await captureRequestBody('gemini-3.7-flash', 'minimal');
+
+    expect(body).toMatchObject({
+      model: 'gemini-3.7-flash-low',
+      request: {
+        generationConfig: {
+          thinkingConfig: { includeThoughts: true, thinkingLevel: 'low' },
+        },
+      },
+    });
+  });
+
+  it('keeps a manually configured Gemini 3.5 medium wire ID', async () => {
+    const body = await captureRequestBody('gemini-3.5-flash-low');
+
+    expect(body).toMatchObject({
+      model: 'gemini-3.5-flash-low',
+      request: {
+        generationConfig: {
+          thinkingConfig: { includeThoughts: true, thinkingLevel: 'medium' },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- expose Gemini 3.5, 3.6, and the current default Gemini 3.7 Flash model in the Antigravity catalog
- translate canonical Flash IDs and reasoning levels to the runtime IDs accepted by Antigravity
- preserve all known Gemini 3.5 wire IDs so repeated resolution and manually configured runtime IDs cannot be downgraded
- cover the final `streamChat` request `model` and `thinkingConfig` without requiring online credentials

## Root cause

The Antigravity provider used a stale hard-coded model list, so the current Flash models did not appear. Requests for a manually configured bare `gemini-3.6-flash` ID were forwarded unchanged, but Antigravity accepts tier-specific runtime IDs, which caused the reported 404. The generic suffix parser also treated the valid Gemini 3.5 medium wire ID `gemini-3.5-flash-low` as the canonical low tier and downgraded it to the extra-low route.

## Validation

- targeted resolver and `streamChat` Vitest coverage: 27 tests passed
- TypeScript source and test projects passed
- `npm run test:unit -- --exclude test/unit/plan4-provider-catalog.test.ts`: 104 files and 1245 tests passed
- the excluded DeepSeek FIM assertion fails identically on unmodified `main` and is unrelated to this change

Fixes #285
