### PR TITLE
fix(openai): send one Chat Completions token limit

### DIFF
--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -148,6 +148,39 @@ function getModelFamily(model: { id: string; family?: string }): string {
   return model.family ?? getBaseModelId(model.id);
 }
 
+const OPENAI_MAX_COMPLETION_TOKEN_FAMILIES = [
+  'codex-mini-latest',
+  'gpt-5',
+  'o1',
+  'o3',
+  'o4-mini',
+  'gpt-oss-120b',
+  'gpt-oss-20b',
+] as const;
+
+function usesOpenAIMaxCompletionTokens(model: {
+  id: string;
+  family?: string;
+}): boolean {
+  // OpenRouter, NVIDIA, and similar catalogs namespace model IDs. Azure model
+  // IDs may instead be opaque deployment names, so an explicit family must
+  // remain authoritative when one is configured.
+  const family = getModelFamily(model).trim().toLowerCase();
+  const unnamespacedFamily = family.slice(family.lastIndexOf('/') + 1);
+
+  if (unnamespacedFamily.startsWith('mimo-')) {
+    return true;
+  }
+
+  return OPENAI_MAX_COMPLETION_TOKEN_FAMILIES.some(
+    (expected) =>
+      unnamespacedFamily === expected ||
+      unnamespacedFamily.startsWith(`${expected}-`) ||
+      unnamespacedFamily.startsWith(`${expected}.`) ||
+      unnamespacedFamily.startsWith(`${expected}:`),
+  );
+}
+
 function modelFamilyIncludes(
   model: { id: string; family?: string },
   expected: string,
@@ -505,32 +538,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
       'api.moonshot.ai',
       'api.kimi.com',
     ],
-    supportedFamilys: [
-      'codex-mini-latest',
-      'gpt-5.2',
-      'gpt-5.1',
-      'gpt-5.1-codex',
-      'gpt-5.1-codex-max',
-      'gpt-5.1-codex-mini',
-      'gpt-5',
-      'gpt-5-codex',
-      'gpt-5-mini',
-      'gpt-5-nano',
-      'gpt-5-pro',
-      'o1',
-      'o1-mini',
-      'o1-preview',
-      'o1-pro',
-      'o3',
-      'o3-deep-research',
-      'o3-mini',
-      'o3-pro',
-      'o4-mini',
-      'o4-mini-deep-research',
-      'gpt-oss-120b',
-      'gpt-oss-20b',
-      'mimo-',
-    ],
+    customCheckers: [(model) => usesOpenAIMaxCompletionTokens(model)],
   },
   [FeatureId.OpenAIOnlyMaxTokens]: {
     supportedProviders: [

--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -548,6 +548,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
       'tokenhub-intl.tencentmaas.com',
       'api.lkeap.cloud.tencent.com',
       'router.huggingface.co',
+      'integrate.api.nvidia.com',
       'qianfan.baidubce.com',
       'portal.qwen.ai',
       'api.siliconflow.cn',

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -1138,6 +1138,16 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
 
     const headers = this.buildHeaders(credential, model, sanitizedMessages);
     const serviceTier = resolveOpenAIServiceTier(this.config, model);
+    // Provider wire constraints override model-family hints; unknown compatible
+    // endpoints default to the broadly supported legacy parameter.
+    const maxOutputTokenParams =
+      model.maxOutputTokens === undefined
+        ? {}
+        : useOnlyMaxTokens
+          ? { max_tokens: model.maxOutputTokens }
+          : useOnlyMaxCompletionTokens
+            ? { max_completion_tokens: model.maxOutputTokens }
+            : { max_tokens: model.maxOutputTokens };
 
     const baseBody: ChatCompletionCreateParamsBase = {
       model: getBaseModelId(model.id),
@@ -1153,16 +1163,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       ...(useMaxInputTokens && model.maxInputTokens !== undefined
         ? { max_input_tokens: model.maxInputTokens }
         : {}),
-      ...(model.maxOutputTokens !== undefined
-        ? useOnlyMaxCompletionTokens
-          ? { max_completion_tokens: model.maxOutputTokens }
-          : useOnlyMaxTokens
-            ? { max_tokens: model.maxOutputTokens }
-            : {
-                max_tokens: model.maxOutputTokens,
-                max_completion_tokens: model.maxOutputTokens,
-              }
-        : {}),
+      ...maxOutputTokenParams,
       ...(model.temperature !== undefined
         ? { temperature: model.temperature }
         : {}),

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -126,6 +126,56 @@ type OpenAIChatCompletionMarkerData = {
   usage?: CopilotUsage;
 };
 
+type ChatCompletionTokenLimitKey =
+  | 'max_tokens'
+  | 'max_completion_tokens';
+
+function readExtraBodyTokenLimit(
+  extraBody: Record<string, unknown> | undefined,
+  preferredKey: ChatCompletionTokenLimitKey,
+): unknown {
+  if (!extraBody) {
+    return undefined;
+  }
+
+  const alternateKey =
+    preferredKey === 'max_tokens'
+      ? 'max_completion_tokens'
+      : 'max_tokens';
+  const preferredValue = extraBody[preferredKey];
+  return preferredValue !== undefined
+    ? preferredValue
+    : extraBody[alternateKey];
+}
+
+function normalizeChatCompletionTokenLimit(
+  body: ChatCompletionCreateParamsBase,
+  preferredKey: ChatCompletionTokenLimitKey,
+  maxOutputTokens: number | undefined,
+  providerExtraBody: Record<string, unknown> | undefined,
+  modelExtraBody: Record<string, unknown> | undefined,
+): void {
+  const modelOverride = readExtraBodyTokenLimit(modelExtraBody, preferredKey);
+  const providerOverride = readExtraBodyTokenLimit(
+    providerExtraBody,
+    preferredKey,
+  );
+  const value =
+    modelOverride !== undefined
+      ? modelOverride
+      : providerOverride !== undefined
+        ? providerOverride
+        : maxOutputTokens;
+
+  // extraBody is merged last and may contain either alias. Re-establish the
+  // provider/model wire contract on the final body so both can never be sent.
+  Reflect.deleteProperty(body, 'max_tokens');
+  Reflect.deleteProperty(body, 'max_completion_tokens');
+  if (value !== undefined) {
+    Reflect.set(body, preferredKey, value);
+  }
+}
+
 type NullableChoices<T extends { choices: unknown }> = Omit<T, 'choices'> & {
   choices: T['choices'] | null;
 };
@@ -1138,16 +1188,14 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
 
     const headers = this.buildHeaders(credential, model, sanitizedMessages);
     const serviceTier = resolveOpenAIServiceTier(this.config, model);
-    // Provider wire constraints override model-family hints; unknown compatible
+    // Provider wire constraints override model-family hints. Opaque deployment
+    // names (including Azure) should set model.family; otherwise compatible
     // endpoints default to the broadly supported legacy parameter.
-    const maxOutputTokenParams =
-      model.maxOutputTokens === undefined
-        ? {}
-        : useOnlyMaxTokens
-          ? { max_tokens: model.maxOutputTokens }
-          : useOnlyMaxCompletionTokens
-            ? { max_completion_tokens: model.maxOutputTokens }
-            : { max_tokens: model.maxOutputTokens };
+    const tokenLimitKey: ChatCompletionTokenLimitKey = useOnlyMaxTokens
+      ? 'max_tokens'
+      : useOnlyMaxCompletionTokens
+        ? 'max_completion_tokens'
+        : 'max_tokens';
 
     const baseBody: ChatCompletionCreateParamsBase = {
       model: getBaseModelId(model.id),
@@ -1163,7 +1211,6 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       ...(useMaxInputTokens && model.maxInputTokens !== undefined
         ? { max_input_tokens: model.maxInputTokens }
         : {}),
-      ...maxOutputTokenParams,
       ...(model.temperature !== undefined
         ? { temperature: model.temperature }
         : {}),
@@ -1186,6 +1233,13 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
     Object.assign(
       baseBody,
       reasoningExtraBody,
+      this.config.extraBody,
+      model.extraBody,
+    );
+    normalizeChatCompletionTokenLimit(
+      baseBody,
+      tokenLimitKey,
+      model.maxOutputTokens,
       this.config.extraBody,
       model.extraBody,
     );

--- a/test/unit/openai-chat-max-token-serialization.test.ts
+++ b/test/unit/openai-chat-max-token-serialization.test.ts
@@ -390,14 +390,24 @@ describe('OpenAI Chat Completions max token serialization', () => {
       expectedKey: 'max_tokens',
     },
     {
-      name: 'recognizes a namespaced OpenAI model from NVIDIA',
+      name: 'uses the NVIDIA max_tokens protocol for namespaced GPT-OSS 120B',
       providerConfig: provider('https://integrate.api.nvidia.com/v1'),
       model: {
         id: 'openai/gpt-oss-120b',
         maxOutputTokens: 71,
         stream: true,
       },
-      expectedKey: 'max_completion_tokens',
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'uses the NVIDIA max_tokens protocol for namespaced GPT-OSS 20B',
+      providerConfig: provider('https://integrate.api.nvidia.com/v1'),
+      model: {
+        id: 'openai/gpt-oss-20b',
+        maxOutputTokens: 72,
+        stream: false,
+      },
+      expectedKey: 'max_tokens',
     },
     {
       name: 'keeps max_tokens for a namespaced DeepSeek model from NVIDIA',

--- a/test/unit/openai-chat-max-token-serialization.test.ts
+++ b/test/unit/openai-chat-max-token-serialization.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted((): { fetcher: typeof fetch } => ({
+  fetcher: async () => {
+    throw new Error('Test fetcher was not configured');
+  },
+}));
+
+vi.mock('vscode', () => {
+  class LanguageModelTextPart {
+    constructor(readonly value: string) {}
+  }
+  class LanguageModelThinkingPart {
+    constructor(
+      readonly value: string | string[],
+      readonly id?: string,
+      readonly metadata?: Record<string, unknown>,
+    ) {}
+  }
+  class LanguageModelToolCallPart {
+    constructor(
+      readonly callId: string,
+      readonly name: string,
+      readonly input: object,
+    ) {}
+  }
+  class LanguageModelToolResultPart {
+    constructor(
+      readonly callId: string,
+      readonly content: unknown[],
+    ) {}
+  }
+  class LanguageModelDataPart {
+    constructor(
+      readonly data: Uint8Array,
+      readonly mimeType: string,
+    ) {}
+  }
+
+  return {
+    env: { language: 'en' },
+    extensions: { getExtension: () => undefined },
+    l10n: { t: (message: string) => message },
+    LanguageModelTextPart,
+    LanguageModelThinkingPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelToolResultPart2: LanguageModelToolResultPart,
+    LanguageModelDataPart,
+    LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelChatToolMode: { Auto: 1, Required: 2 },
+    window: {
+      createOutputChannel: () => ({
+        info: () => undefined,
+        error: () => undefined,
+        warn: () => undefined,
+        debug: () => undefined,
+        trace: () => undefined,
+        append: () => undefined,
+        appendLine: () => undefined,
+        replace: () => undefined,
+        clear: () => undefined,
+        show: () => undefined,
+        hide: () => undefined,
+        dispose: () => undefined,
+        name: 'test',
+        logLevel: 2,
+        onDidChangeLogLevel: () => ({ dispose: () => undefined }),
+      }),
+    },
+    workspace: {
+      getConfiguration: () => ({
+        get: <T>(_key: string, fallback: T) => fallback,
+      }),
+    },
+  };
+});
+
+vi.mock('../../src/config-store', () => ({
+  CONFIG_NAMESPACE: 'unifyChatProvider',
+}));
+
+vi.mock('../../src/official-models-manager', () => ({
+  officialModelsManager: {},
+}));
+
+vi.mock('../../src/client/definitions', () => {
+  const featureId = {
+    OpenAIOnlyMaxCompletionTokens: 'openai_only-max-completion-tokens',
+    OpenAIOnlyMaxTokens: 'openai_only-max-tokens',
+  };
+  return {
+    FeatureId: featureId,
+    FEATURES: {
+      [featureId.OpenAIOnlyMaxCompletionTokens]: {
+        supportedFamilys: ['gpt-5', 'o1', 'o3', 'o4-mini'],
+      },
+      [featureId.OpenAIOnlyMaxTokens]: {
+        supportedProviders: ['api.mistral.ai', 'api.siliconflow.cn'],
+      },
+    },
+    PROVIDER_TYPES: {},
+  };
+});
+
+vi.mock('../../src/client/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/client/utils')>();
+  return {
+    ...actual,
+    createCustomFetch: () => transport.fetcher,
+  };
+});
+
+import * as vscode from 'vscode';
+import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+import { RequestLogger } from '../../src/logger';
+import type {
+  ChatRequestTrace,
+  ModelConfig,
+  ProviderConfig,
+} from '../../src/types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function readRequestBody(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Record<string, unknown>> {
+  const text =
+    typeof init?.body === 'string'
+      ? init.body
+      : input instanceof Request
+        ? await input.clone().text()
+        : undefined;
+  if (text === undefined) {
+    throw new Error('Expected a JSON request body');
+  }
+
+  const parsed: unknown = JSON.parse(text);
+  if (!isRecord(parsed)) {
+    throw new Error('Expected a JSON object request body');
+  }
+  return parsed;
+}
+
+function successfulCompletion(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-test',
+      object: 'chat.completion',
+      created: 0,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok', refusal: null },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function duplicateTokenLimitError(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message:
+          "Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.",
+        type: 'invalid_request_error',
+      },
+    }),
+    { status: 400, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function cancellationToken(): vscode.CancellationToken {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose: () => undefined }),
+  };
+}
+
+function trace(): ChatRequestTrace {
+  return {
+    performance: { tts: Date.now(), ttf: 0, ttft: 0, tps: 0, tl: 0 },
+  };
+}
+
+async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of source) {
+    values.push(value);
+  }
+  return values;
+}
+
+async function sendChat(
+  providerConfig: ProviderConfig,
+  model: ModelConfig,
+): Promise<Record<string, unknown>> {
+  let requestBody: Record<string, unknown> | undefined;
+  transport.fetcher = async (input, init) => {
+    requestBody = await readRequestBody(input, init);
+    if (
+      requestBody['max_tokens'] !== undefined &&
+      requestBody['max_completion_tokens'] !== undefined
+    ) {
+      return duplicateTokenLimitError();
+    }
+    return successfulCompletion(model.id);
+  };
+
+  const messages: vscode.LanguageModelChatRequestMessage[] = [
+    {
+      role: vscode.LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new vscode.LanguageModelTextPart('hello')],
+    },
+  ];
+  const parts = await collect(
+    new OpenAIChatCompletionProvider(providerConfig).streamChat(
+      model.id,
+      model,
+      messages,
+      {
+        requestInitiator: 'test',
+        toolMode: vscode.LanguageModelChatToolMode.Auto,
+        tools: [],
+      },
+      trace(),
+      cancellationToken(),
+      new RequestLogger('openai-chat-max-token-test'),
+      { kind: 'token', token: 'test-key' },
+    ),
+  );
+
+  expect(
+    parts.some(
+      (part) =>
+        part instanceof vscode.LanguageModelTextPart && part.value === 'ok',
+    ),
+  ).toBe(true);
+  if (requestBody === undefined) {
+    throw new Error('Expected the Chat Completions request to be sent');
+  }
+  return requestBody;
+}
+
+beforeEach(() => {
+  transport.fetcher = async () => {
+    throw new Error('Test fetcher was not configured');
+  };
+});
+
+describe('OpenAI Chat Completions max token serialization', () => {
+  it('sends only max_tokens for a legacy model through a custom compatible gateway', async () => {
+    const body = await sendChat(
+      {
+        type: 'openai-chat-completion',
+        name: 'NewAPI',
+        baseUrl: 'https://newapi.example.test/v1',
+        models: [],
+      },
+      {
+        id: 'gpt-4.1-mini',
+        maxOutputTokens: 64,
+        stream: false,
+      },
+    );
+
+    expect(body['max_tokens']).toBe(64);
+    expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+
+  it('keeps max_completion_tokens for models that require it', async () => {
+    const body = await sendChat(
+      {
+        type: 'openai-chat-completion',
+        name: 'NewAPI',
+        baseUrl: 'https://newapi.example.test/v1',
+        models: [],
+      },
+      {
+        id: 'gpt-5.5',
+        maxOutputTokens: 128,
+        stream: false,
+      },
+    );
+
+    expect(body['max_completion_tokens']).toBe(128);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it('keeps max_tokens for providers that explicitly require it', async () => {
+    const body = await sendChat(
+      {
+        type: 'openai-chat-completion',
+        name: 'Mistral AI',
+        baseUrl: 'https://api.mistral.ai/v1',
+        models: [],
+      },
+      {
+        id: 'mistral-medium-3-5',
+        maxOutputTokens: 256,
+        stream: false,
+      },
+    );
+
+    expect(body['max_tokens']).toBe(256);
+    expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+
+  it('prioritizes a provider max_tokens contract over a model-family hint', async () => {
+    const body = await sendChat(
+      {
+        type: 'openai-chat-completion',
+        name: 'SiliconFlow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        models: [],
+      },
+      {
+        id: 'gpt-5.5',
+        maxOutputTokens: 512,
+        stream: false,
+      },
+    );
+
+    expect(body['max_tokens']).toBe(512);
+    expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+});

--- a/test/unit/openai-chat-max-token-serialization.test.ts
+++ b/test/unit/openai-chat-max-token-serialization.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const transport = vi.hoisted((): { fetcher: typeof fetch } => ({
   fetcher: async () => {
@@ -84,25 +84,6 @@ vi.mock('../../src/official-models-manager', () => ({
   officialModelsManager: {},
 }));
 
-vi.mock('../../src/client/definitions', () => {
-  const featureId = {
-    OpenAIOnlyMaxCompletionTokens: 'openai_only-max-completion-tokens',
-    OpenAIOnlyMaxTokens: 'openai_only-max-tokens',
-  };
-  return {
-    FeatureId: featureId,
-    FEATURES: {
-      [featureId.OpenAIOnlyMaxCompletionTokens]: {
-        supportedFamilys: ['gpt-5', 'o1', 'o3', 'o4-mini'],
-      },
-      [featureId.OpenAIOnlyMaxTokens]: {
-        supportedProviders: ['api.mistral.ai', 'api.siliconflow.cn'],
-      },
-    },
-    PROVIDER_TYPES: {},
-  };
-});
-
 vi.mock('../../src/client/utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/client/utils')>();
   return {
@@ -112,13 +93,23 @@ vi.mock('../../src/client/utils', async (importOriginal) => {
 });
 
 import * as vscode from 'vscode';
-import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
 import { RequestLogger } from '../../src/logger';
 import type {
   ChatRequestTrace,
   ModelConfig,
   ProviderConfig,
 } from '../../src/types';
+
+let OpenAIChatCompletionProvider: typeof import('../../src/client/openai/chat-completion-client').OpenAIChatCompletionProvider;
+
+beforeAll(async () => {
+  // Load the real feature registry first. It owns provider classes and avoids
+  // entering its circular dependency graph from a provider leaf module.
+  await import('../../src/client/definitions');
+  ({ OpenAIChatCompletionProvider } = await import(
+    '../../src/client/openai/chat-completion-client'
+  ));
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -165,6 +156,44 @@ function successfulCompletion(model: string): Response {
   );
 }
 
+function successfulStream(model: string): Response {
+  const chunks = [
+    {
+      id: 'chatcmpl-test',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: 'ok' },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+    },
+    {
+      id: 'chatcmpl-test',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    },
+  ];
+  const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`;
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
 function duplicateTokenLimitError(): Response {
   return new Response(
     JSON.stringify({
@@ -199,6 +228,19 @@ async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
   return values;
 }
 
+function provider(
+  baseUrl: string,
+  extraBody?: Record<string, unknown>,
+): ProviderConfig {
+  return {
+    type: 'openai-chat-completion',
+    name: 'Test provider',
+    baseUrl,
+    models: [],
+    ...(extraBody ? { extraBody } : {}),
+  };
+}
+
 async function sendChat(
   providerConfig: ProviderConfig,
   model: ModelConfig,
@@ -212,7 +254,9 @@ async function sendChat(
     ) {
       return duplicateTokenLimitError();
     }
-    return successfulCompletion(model.id);
+    return requestBody['stream'] === true
+      ? successfulStream(model.id)
+      : successfulCompletion(model.id);
   };
 
   const messages: vscode.LanguageModelChatRequestMessage[] = [
@@ -248,7 +292,22 @@ async function sendChat(
   if (requestBody === undefined) {
     throw new Error('Expected the Chat Completions request to be sent');
   }
+  expect(requestBody['stream']).toBe(model.stream ?? true);
   return requestBody;
+}
+
+type TokenLimitKey = 'max_tokens' | 'max_completion_tokens';
+
+function expectOnlyTokenLimit(
+  body: Record<string, unknown>,
+  key: TokenLimitKey,
+  value: unknown,
+): void {
+  const alternate =
+    key === 'max_tokens' ? 'max_completion_tokens' : 'max_tokens';
+  expect(body).toHaveProperty(key);
+  expect(body[key]).toEqual(value);
+  expect(body).not.toHaveProperty(alternate);
 }
 
 beforeEach(() => {
@@ -258,79 +317,234 @@ beforeEach(() => {
 });
 
 describe('OpenAI Chat Completions max token serialization', () => {
-  it('sends only max_tokens for a legacy model through a custom compatible gateway', async () => {
-    const body = await sendChat(
-      {
-        type: 'openai-chat-completion',
-        name: 'NewAPI',
-        baseUrl: 'https://newapi.example.test/v1',
-        models: [],
+  const routingCases: Array<{
+    name: string;
+    providerConfig: ProviderConfig;
+    model: ModelConfig;
+    expectedKey: TokenLimitKey;
+  }> = [
+    {
+      name: 'defaults a legacy custom gateway to max_tokens (non-streaming)',
+      providerConfig: provider('https://newapi.example.test/v1'),
+      model: { id: 'gpt-4.1-mini', maxOutputTokens: 64, stream: false },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'uses max_completion_tokens for a GPT-5 family (streaming)',
+      providerConfig: provider('https://newapi.example.test/v1'),
+      model: { id: 'gpt-5.5', maxOutputTokens: 65, stream: true },
+      expectedKey: 'max_completion_tokens',
+    },
+    {
+      name: 'does not classify gpt-50 as the gpt-5 family',
+      providerConfig: provider('https://newapi.example.test/v1'),
+      model: { id: 'gpt-50-preview', maxOutputTokens: 66, stream: false },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'uses an explicit GPT-5 family for an opaque Azure deployment',
+      providerConfig: provider(
+        'https://example-resource.openai.azure.com/openai/v1',
+      ),
+      model: {
+        id: 'production-chat',
+        family: 'gpt-5.5',
+        maxOutputTokens: 67,
+        stream: true,
       },
+      expectedKey: 'max_completion_tokens',
+    },
+    {
+      name: 'defaults an opaque Azure deployment without family metadata to max_tokens',
+      providerConfig: provider(
+        'https://example-resource.openai.azure.com/openai/v1',
+      ),
+      model: {
+        id: 'production-chat',
+        maxOutputTokens: 68,
+        stream: false,
+      },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'honors an explicit legacy family over a GPT-like deployment name',
+      providerConfig: provider(
+        'https://example-resource.openai.azure.com/openai/v1',
+      ),
+      model: {
+        id: 'gpt-5-production',
+        family: 'gpt-4.1',
+        maxOutputTokens: 69,
+        stream: true,
+      },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'keeps max_tokens for a DeepSeek model',
+      providerConfig: provider('https://api.deepseek.com/v1'),
+      model: {
+        id: 'deepseek-chat',
+        maxOutputTokens: 70,
+        stream: false,
+      },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'recognizes a namespaced OpenAI model from NVIDIA',
+      providerConfig: provider('https://integrate.api.nvidia.com/v1'),
+      model: {
+        id: 'openai/gpt-oss-120b',
+        maxOutputTokens: 71,
+        stream: true,
+      },
+      expectedKey: 'max_completion_tokens',
+    },
+    {
+      name: 'keeps max_tokens for a namespaced DeepSeek model from NVIDIA',
+      providerConfig: provider('https://integrate.api.nvidia.com/v1'),
+      model: {
+        id: 'deepseek-ai/deepseek-v4-pro',
+        maxOutputTokens: 72,
+        stream: false,
+      },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'recognizes a namespaced GPT-5 model from OpenRouter',
+      providerConfig: provider('https://openrouter.ai/api/v1'),
+      model: {
+        id: 'openai/gpt-5.5',
+        maxOutputTokens: 73,
+        stream: true,
+      },
+      expectedKey: 'max_completion_tokens',
+    },
+    {
+      name: 'keeps max_tokens for a namespaced DeepSeek model from OpenRouter',
+      providerConfig: provider('https://openrouter.ai/api/v1'),
+      model: {
+        id: 'deepseek/deepseek-chat',
+        maxOutputTokens: 74,
+        stream: false,
+      },
+      expectedKey: 'max_tokens',
+    },
+    {
+      name: 'honors a provider max_completion_tokens protocol for an opaque model',
+      providerConfig: provider('https://api.cerebras.ai/v1'),
+      model: {
+        id: 'deployment-alias',
+        maxOutputTokens: 75,
+        stream: true,
+      },
+      expectedKey: 'max_completion_tokens',
+    },
+    {
+      name: 'prioritizes a provider max_tokens protocol over a GPT-5 family',
+      providerConfig: provider('https://api.siliconflow.cn/v1'),
+      model: { id: 'gpt-5.5', maxOutputTokens: 76, stream: false },
+      expectedKey: 'max_tokens',
+    },
+  ];
+
+  for (const testCase of routingCases) {
+    it(testCase.name, async () => {
+      const body = await sendChat(testCase.providerConfig, testCase.model);
+      expectOnlyTokenLimit(
+        body,
+        testCase.expectedKey,
+        testCase.model.maxOutputTokens,
+      );
+    });
+  }
+
+  it('normalizes a later model max_completion_tokens override to max_tokens', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1', { max_tokens: 81 }),
       {
         id: 'gpt-4.1-mini',
-        maxOutputTokens: 64,
-        stream: false,
+        maxOutputTokens: 80,
+        stream: true,
+        extraBody: { max_completion_tokens: 82 },
       },
     );
 
-    expect(body['max_tokens']).toBe(64);
-    expect(body).not.toHaveProperty('max_completion_tokens');
+    expectOnlyTokenLimit(body, 'max_tokens', 82);
   });
 
-  it('keeps max_completion_tokens for models that require it', async () => {
+  it('normalizes a later model max_tokens override to max_completion_tokens', async () => {
     const body = await sendChat(
-      {
-        type: 'openai-chat-completion',
-        name: 'NewAPI',
-        baseUrl: 'https://newapi.example.test/v1',
-        models: [],
-      },
+      provider('https://newapi.example.test/v1', {
+        max_completion_tokens: 91,
+      }),
       {
         id: 'gpt-5.5',
-        maxOutputTokens: 128,
+        maxOutputTokens: 90,
         stream: false,
+        extraBody: { max_tokens: 92 },
       },
     );
 
-    expect(body['max_completion_tokens']).toBe(128);
+    expectOnlyTokenLimit(body, 'max_completion_tokens', 92);
+  });
+
+  it('uses the protocol-preferred alias when one extraBody contains both', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1', {
+        max_tokens: 101,
+        max_completion_tokens: 102,
+      }),
+      { id: 'gpt-5.5', maxOutputTokens: 100, stream: true },
+    );
+
+    expectOnlyTokenLimit(body, 'max_completion_tokens', 102);
+  });
+
+  it('maps a null opposite alias without falling back to maxOutputTokens', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1'),
+      {
+        id: 'gpt-5.5',
+        maxOutputTokens: 110,
+        stream: false,
+        extraBody: { max_tokens: null },
+      },
+    );
+
+    expectOnlyTokenLimit(body, 'max_completion_tokens', null);
+  });
+
+  it('ignores an undefined alias and retains maxOutputTokens', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1', {
+        max_completion_tokens: undefined,
+      }),
+      {
+        id: 'gpt-4.1-mini',
+        maxOutputTokens: 120,
+        stream: true,
+      },
+    );
+
+    expectOnlyTokenLimit(body, 'max_tokens', 120);
+  });
+
+  it('retains a zero token limit instead of treating it as absent', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1'),
+      { id: 'gpt-5.5', maxOutputTokens: 0, stream: false },
+    );
+
+    expectOnlyTokenLimit(body, 'max_completion_tokens', 0);
+  });
+
+  it('omits both aliases when no output limit is configured', async () => {
+    const body = await sendChat(
+      provider('https://newapi.example.test/v1'),
+      { id: 'gpt-4.1-mini', maxOutputTokens: undefined, stream: true },
+    );
+
     expect(body).not.toHaveProperty('max_tokens');
-  });
-
-  it('keeps max_tokens for providers that explicitly require it', async () => {
-    const body = await sendChat(
-      {
-        type: 'openai-chat-completion',
-        name: 'Mistral AI',
-        baseUrl: 'https://api.mistral.ai/v1',
-        models: [],
-      },
-      {
-        id: 'mistral-medium-3-5',
-        maxOutputTokens: 256,
-        stream: false,
-      },
-    );
-
-    expect(body['max_tokens']).toBe(256);
-    expect(body).not.toHaveProperty('max_completion_tokens');
-  });
-
-  it('prioritizes a provider max_tokens contract over a model-family hint', async () => {
-    const body = await sendChat(
-      {
-        type: 'openai-chat-completion',
-        name: 'SiliconFlow',
-        baseUrl: 'https://api.siliconflow.cn/v1',
-        models: [],
-      },
-      {
-        id: 'gpt-5.5',
-        maxOutputTokens: 512,
-        stream: false,
-      },
-    );
-
-    expect(body['max_tokens']).toBe(512);
     expect(body).not.toHaveProperty('max_completion_tokens');
   });
 });


### PR DESCRIPTION
## Summary

- serialize exactly one Chat Completions output-token limit after all provider/model `extraBody` merges
- normalize either extra-body alias onto the selected wire parameter, with model overrides taking precedence over provider overrides and the protocol-preferred alias winning when one layer supplies both
- match completion-token model families at real boundaries and through provider namespaces, while honoring explicit `model.family` metadata for opaque deployment names such as Azure
- cover the final OpenAI SDK payload for streaming and non-streaming requests across custom gateways, Azure, DeepSeek, NVIDIA, OpenRouter, and explicit provider protocols

## Root cause

When neither token-limit feature matched, the Chat Completions request body included both `max_tokens` and `max_completion_tokens`. Strict OpenAI-compatible gateways such as the reported NewAPI deployment reject that ambiguity with HTTP 400 before dispatching the model request.

Selecting one field before merging `extraBody` was not sufficient because provider or model overrides could reintroduce the opposite alias. The request now resolves the effective value after every merge, deletes both aliases, and writes only the field selected by the provider/model protocol. `null` and `0` remain explicit values, `undefined` is ignored, and no field is emitted when no limit is configured.

The model-family route now strips catalog namespaces and requires a real family delimiter, so `openai/gpt-5.5` is recognized while `gpt-50` is not. Explicit `model.family` is authoritative. This is important for Azure, where `model` is commonly an opaque deployment name: configure the deployed family (for example `gpt-5.5`) to select `max_completion_tokens`; without inferable or explicit family metadata, the compatibility default remains `max_tokens`. Explicit provider protocols still take precedence over family hints.

NVIDIA's hosted `integrate.api.nvidia.com` endpoint is therefore marked as a provider-level `max_tokens` protocol. That constraint overrides the otherwise applicable GPT-OSS family hint for both `openai/gpt-oss-20b` and `openai/gpt-oss-120b`.

This follows the current [OpenAI Chat Completions parameter contract](https://developers.openai.com/api/reference/cli/resources/chat/subresources/completions/methods/create), where `max_tokens` is deprecated and incompatible with o-series models; [Azure's deployment-name guidance](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/chatgpt), which calls out `max_completion_tokens` for reasoning models; and NVIDIA's hosted schemas for [GPT-OSS 20B](https://docs.api.nvidia.com/nim/reference/openai-gpt-oss-20b-infer) and [GPT-OSS 120B](https://docs.api.nvidia.com/nim/reference/openai-gpt-oss-120b-infer), which expose `max_tokens` from 1 through 4096.

## Validation

- `npx vitest run test/unit/openai-chat-max-token-serialization.test.ts` (21 passed; real `FEATURES`, final SDK JSON body, stream true/false)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `npm run test:unit` reached Vitest with 104 files and 1,252 tests passing; the sole failure is the unrelated current-main DeepSeek FIM catalog assertion
- reproduced that same catalog failure on clean `origin/main@616a3bd`
- `npm run verify:chat-lib`
- `npm run l10n:check`
- `git diff --check`

Fixes #279
