### PR TITLE
fix(openai): nest Z.AI clear_thinking parameter

### DIFF
--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -473,9 +473,17 @@ export enum FeatureId {
    */
   OpenAIUseDisableReasoningParam = 'openai_use-disable-reasoning-param',
   /**
-   * @see https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode
+   * Use `thinking.clear_thinking` in Z.AI-compatible Chat Completion APIs.
+   *
+   * @see https://docs.z.ai/api-reference/llm/chat-completion
    */
   OpenAIUseClearThinking = 'openai_use-clear-thinking',
+  /**
+   * Use a provider-specific top-level `clear_thinking` variant.
+   *
+   * @see https://inference-docs.cerebras.ai/api-reference/chat-completions
+   */
+  OpenAIUseTopLevelClearThinking = 'openai_use-top-level-clear-thinking',
   /**
    * Use `reasoning_split` parameter in OpenAI-compatible Chat Completion APIs.
    */
@@ -896,6 +904,8 @@ export const FEATURES: Record<FeatureId, Feature> = {
   },
   [FeatureId.OpenAIUseClearThinking]: {
     supportedProviders: ['open.bigmodel.cn', 'api.z.ai'],
+  },
+  [FeatureId.OpenAIUseTopLevelClearThinking]: {
     customCheckers: [
       // Checker for Cerebras GLM 4.7 model:
       (model, provider) =>
@@ -903,7 +913,7 @@ export const FEATURES: Record<FeatureId, Feature> = {
         matchModelFamily(model.family ?? getBaseModelId(model.id), [
           'zai-glm-4.7',
         ]),
-      // Checker for Nvidia GLM 4.7 model:
+      // Preserve the existing Nvidia GLM 4.7 wire shape.
       (model, provider) =>
         matchProvider(provider.baseUrl, 'integrate.api.nvidia.com') &&
         matchModelFamily(model.family ?? getBaseModelId(model.id), [

--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -673,6 +673,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
   private buildReasoningParams(
     model: ModelConfig,
     type: ReasoningParamType,
+    useNestedClearThinking = false,
   ): Partial<ChatCompletionCreateParamsBase> {
     const thinking = model.thinking;
     const isDisabled = this.isThinkingDisabled(thinking);
@@ -716,7 +717,12 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       // @see https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
       case 'thinking': {
         if (!thinking) return {};
-        return { thinking: { type: thinking.type } };
+        return {
+          thinking: this.buildThinkingParam(
+            thinking.type,
+            useNestedClearThinking,
+          ),
+        };
       }
 
       // GLM / DeepSeek V4 — `thinking: { type }` + `reasoning_effort: high|max`
@@ -728,13 +734,17 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
         }
         if (isDisabled) {
           return {
-            thinking: { type: 'disabled' },
+            thinking: this.buildThinkingParam(
+              'disabled',
+              useNestedClearThinking,
+            ),
           };
         }
         return {
-          thinking: {
-            type: this.normalizeThinkingTypeForDeepSeek(thinking.type),
-          },
+          thinking: this.buildThinkingParam(
+            this.normalizeThinkingTypeForDeepSeek(thinking.type),
+            useNestedClearThinking,
+          ),
         };
       }
 
@@ -745,7 +755,10 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
           return {};
         }
         return {
-          thinking: { type: 'enabled' },
+          thinking: this.buildThinkingParam(
+            'enabled',
+            useNestedClearThinking,
+          ),
         };
       }
 
@@ -757,12 +770,18 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
         }
         if (thinking.type === 'disabled') {
           return {
-            thinking: { type: 'disabled' },
+            thinking: this.buildThinkingParam(
+              'disabled',
+              useNestedClearThinking,
+            ),
             reasoning_effort: 'minimal',
           };
         }
         return {
-          thinking: { type: thinking.type },
+          thinking: this.buildThinkingParam(
+            thinking.type,
+            useNestedClearThinking,
+          ),
           ...(thinking.effort == null
             ? {}
             : {
@@ -836,6 +855,16 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
         return {};
       }
     }
+  }
+
+  private buildThinkingParam(
+    type: NonNullable<ChatCompletionCreateParamsBase['thinking']>['type'],
+    useNestedClearThinking: boolean,
+  ): NonNullable<ChatCompletionCreateParamsBase['thinking']> {
+    return {
+      type,
+      ...(useNestedClearThinking ? { clear_thinking: false } : {}),
+    };
   }
 
   private isThinkingDisabled(
@@ -1110,8 +1139,13 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       this.config,
       model,
     );
-    const useClearThinking = isFeatureSupported(
+    const useNestedClearThinking = isFeatureSupported(
       FeatureId.OpenAIUseClearThinking,
+      this.config,
+      model,
+    );
+    const useTopLevelClearThinking = isFeatureSupported(
+      FeatureId.OpenAIUseTopLevelClearThinking,
       this.config,
       model,
     );
@@ -1193,13 +1227,17 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
     const baseBody: ChatCompletionCreateParamsBase = {
       model: getBaseModelId(model.id),
       messages: convertedMessages,
-      ...this.buildReasoningParams(model, thinkingParamType),
+      ...this.buildReasoningParams(
+        model,
+        thinkingParamType,
+        useNestedClearThinking,
+      ),
       ...(useThinkingStrategyParam
         ? this.buildThinkingStrategyParam(model)
         : {}),
       ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
       ...(useTopK && model.topK !== undefined ? { top_k: model.topK } : {}),
-      ...(useClearThinking ? { clear_thinking: false } : {}),
+      ...(useTopLevelClearThinking ? { clear_thinking: false } : {}),
       ...(useReasoningSplitParam ? { reasoning_split: true } : {}),
       ...(useMaxInputTokens && model.maxInputTokens !== undefined
         ? { max_input_tokens: model.maxInputTokens }

--- a/src/client/openai/openai.d.ts
+++ b/src/client/openai/openai.d.ts
@@ -91,7 +91,16 @@ declare module 'openai/resources/chat/completions' {
      * @see https://www.volcengine.com/docs/82379/1569618?lang=zh
      * @see https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new
      */
-    thinking?: { type: 'enabled' | 'disabled' | 'auto' };
+    thinking?: {
+      type: 'enabled' | 'disabled' | 'auto';
+
+      /**
+       * Preserve reasoning content from previous turns on Z.AI-compatible APIs.
+       *
+       * @see https://docs.z.ai/api-reference/llm/chat-completion
+       */
+      clear_thinking?: boolean;
+    };
 
     /**
      * Non-standard reasoning effort supported by some OpenAI-compatible providers.
@@ -110,7 +119,10 @@ declare module 'openai/resources/chat/completions' {
       | 'max';
 
     /**
-     * @see https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode
+     * Provider-specific top-level variant. Cerebras documents it for the
+     * `zai-glm-4.7` model.
+     *
+     * @see https://inference-docs.cerebras.ai/api-reference/chat-completions
      */
     clear_thinking?: boolean;
 

--- a/test/unit/openai-clear-thinking.test.ts
+++ b/test/unit/openai-clear-thinking.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => {
+  class EventEmitter<T> {
+    readonly event = (
+      _listener: (value: T) => unknown,
+    ): { dispose: () => void } => ({ dispose: () => undefined });
+    fire(_value: T): void {}
+    dispose(): void {}
+  }
+
+  class ThemeIcon {
+    constructor(readonly id: string) {}
+  }
+
+  return {
+    env: { language: 'en' },
+    EventEmitter,
+    extensions: { getExtension: () => undefined },
+    l10n: {
+      t: (message: string | { message: string }) =>
+        typeof message === 'string' ? message : message.message,
+    },
+    ThemeIcon,
+    workspace: {
+      getConfiguration: () => ({
+        get: (_key: string, fallback?: unknown) => fallback,
+      }),
+    },
+  };
+});
+
+import { FeatureId } from '../../src/client/definitions';
+import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+import { isFeatureSupported } from '../../src/client/utils';
+import type { ModelConfig, ProviderConfig } from '../../src/types';
+
+function providerConfig(baseUrl: string): ProviderConfig {
+  return {
+    type: 'openai-chat-completion',
+    name: 'clear_thinking protocol test',
+    baseUrl,
+    models: [],
+  };
+}
+
+const client = new OpenAIChatCompletionProvider(
+  providerConfig('https://api.z.ai/api/paas/v4'),
+);
+
+function invokeReasoningBuilder(
+  model: ModelConfig,
+  type:
+    | 'thinking'
+    | 'thinking_with_high_max_reasoning_effort'
+    | 'forced_thinking_with_reasoning_effort'
+    | 'disable_reasoning',
+  useNestedClearThinking: boolean,
+): unknown {
+  const builder: unknown = Reflect.get(client, 'buildReasoningParams');
+  if (typeof builder !== 'function') {
+    throw new Error('buildReasoningParams was not found');
+  }
+  return Reflect.apply(builder, client, [model, type, useNestedClearThinking]);
+}
+
+describe('clear_thinking protocol boundaries', () => {
+  it.each([
+    'https://open.bigmodel.cn/api/paas/v4',
+    'https://api.z.ai/api/paas/v4',
+  ])('uses the nested protocol on %s', (baseUrl) => {
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseClearThinking,
+        providerConfig(baseUrl),
+        { id: 'glm-4.7' },
+      ),
+    ).toBe(true);
+  });
+
+  it('uses the documented top-level variant for Cerebras GLM 4.7', () => {
+    const provider = providerConfig('https://api.cerebras.ai/v1');
+    const model = { id: 'zai-glm-4.7' };
+
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseTopLevelClearThinking,
+        provider,
+        model,
+      ),
+    ).toBe(true);
+    expect(
+      isFeatureSupported(FeatureId.OpenAIUseClearThinking, provider, model),
+    ).toBe(false);
+  });
+
+  it('preserves the existing top-level NVIDIA compatibility path', () => {
+    const provider = providerConfig('https://integrate.api.nvidia.com/v1');
+    const model = { id: 'z-ai/glm4.7' };
+
+    expect(
+      isFeatureSupported(FeatureId.OpenAIUseClearThinking, provider, model),
+    ).toBe(false);
+    expect(
+      isFeatureSupported(
+        FeatureId.OpenAIUseTopLevelClearThinking,
+        provider,
+        model,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      type: 'thinking' as const,
+      thinking: { type: 'enabled' as const },
+      expectedType: 'enabled',
+    },
+    {
+      type: 'thinking' as const,
+      thinking: { type: 'disabled' as const },
+      expectedType: 'disabled',
+    },
+    {
+      type: 'thinking_with_high_max_reasoning_effort' as const,
+      thinking: { type: 'auto' as const, effort: 'max' as const },
+      expectedType: 'enabled',
+    },
+    {
+      type: 'forced_thinking_with_reasoning_effort' as const,
+      thinking: { type: 'disabled' as const },
+      expectedType: 'enabled',
+    },
+  ])('nests the flag for $type / $thinking.type', (testCase) => {
+    expect(
+      invokeReasoningBuilder(
+        { id: 'glm-model', thinking: testCase.thinking },
+        testCase.type,
+        true,
+      ),
+    ).toEqual({
+      thinking: {
+        type: testCase.expectedType,
+        clear_thinking: false,
+      },
+    });
+  });
+
+  it('does not emit a standalone flag without a thinking object', () => {
+    expect(
+      invokeReasoningBuilder({ id: 'glm-model' }, 'thinking', true),
+    ).toEqual({});
+  });
+
+  it('does not nest the flag into a protocol without a thinking object', () => {
+    expect(
+      invokeReasoningBuilder(
+        { id: 'zai-glm-4.7', thinking: { type: 'enabled' } },
+        'disable_reasoning',
+        true,
+      ),
+    ).toEqual({ disable_reasoning: false });
+  });
+});


### PR DESCRIPTION
## Summary

- serialize `clear_thinking: false` inside the `thinking` object for Z.AI and BigModel Chat Completions
- retain the provider-specific top-level compatibility path used by Cerebras and NVIDIA
- update the OpenAI SDK augmentation and add protocol-boundary regression coverage

## Root cause

The `OpenAIUseClearThinking` feature selected several provider protocols but always spread `clear_thinking` into the request body at the top level. Z.AI and BigModel define this field as `thinking.clear_thinking`, so their standard API could ignore it and clear historical reasoning despite the extension requesting preserved thinking.

The request builder now keeps the Z.AI-compatible field alongside `thinking.type`. Cerebras continues to use its documented top-level parameter, while the existing NVIDIA wire shape remains unchanged rather than assuming its gateway follows the Z.AI request schema.

## Validation

- `npx vitest run test/unit/openai-clear-thinking.test.ts test/unit/glm-5-3-protocol.test.ts` (47 passed)
- `npm run test:unit` (114 files, 1373 tests passed)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `git diff --check origin/main...HEAD`

Fixes #316
