### PR TITLE
fix(openai): serialize vision tool results correctly

### DIFF
--- a/src/client/openai/chat-completion-client.ts
+++ b/src/client/openai/chat-completion-client.ts
@@ -64,6 +64,7 @@ import {
   ChatCompletion,
   ChatCompletionAssistantMessageParam,
   ChatCompletionChunk,
+  ChatCompletionContentPart,
   ChatCompletionContentPartText,
   ChatCompletionCreateParamsBase,
   ChatCompletionFunctionTool,
@@ -292,10 +293,28 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       ChatCompletionAssistantMessageParam,
       ChatCompletionMessageParam
     >();
+    const pendingToolMessages: ChatCompletionToolMessageParam[] = [];
+    const pendingToolUserContent: ChatCompletionContentPart[] = [];
+    const flushPendingToolResults = (): void => {
+      if (pendingToolMessages.length === 0) {
+        return;
+      }
+
+      outMessages.push(...pendingToolMessages);
+      if (pendingToolUserContent.length > 0) {
+        outMessages.push({
+          role: 'user',
+          content: [...pendingToolUserContent],
+        });
+      }
+      pendingToolMessages.length = 0;
+      pendingToolUserContent.length = 0;
+    };
 
     for (const msg of messages) {
       switch (msg.role) {
         case vscode.LanguageModelChatMessageRole.System:
+          flushPendingToolResults();
           for (const part of msg.content) {
             const parts = this.convertPart(msg.role, part) as
               | ChatCompletionSystemMessageParam
@@ -305,16 +324,26 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
           break;
 
         case vscode.LanguageModelChatMessageRole.User:
-          for (const part of msg.content) {
-            const parts = this.convertPart(msg.role, part) as
-              | ChatCompletionUserMessageParam
-              | ChatCompletionToolMessageParam
-              | undefined;
-            if (parts) outMessages.push(parts);
+          {
+            const converted = this.convertUserMessage(msg);
+            if (converted.hasToolResults) {
+              pendingToolMessages.push(...converted.toolMessages);
+              pendingToolUserContent.push(...converted.userContent);
+              if (converted.hasOrdinaryUserContent) {
+                flushPendingToolResults();
+              }
+            } else if (converted.userContent.length > 0) {
+              flushPendingToolResults();
+              outMessages.push({
+                role: 'user',
+                content: converted.userContent,
+              });
+            }
           }
           break;
 
         case vscode.LanguageModelChatMessageRole.Assistant:
+          flushPendingToolResults();
           {
             const markerParts = msg.content.filter(
               (v): v is vscode.LanguageModelDataPart =>
@@ -356,6 +385,8 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       }
     }
 
+    flushPendingToolResults();
+
     // use raw messages, for details, see parseMessage's NOTE comments.
     for (const [param, raw] of rawMap) {
       const index = outMessages.indexOf(param);
@@ -370,6 +401,125 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
     }
 
     return outMessages;
+  }
+
+  private convertUserMessage(
+    message: vscode.LanguageModelChatRequestMessage,
+  ): {
+    toolMessages: ChatCompletionToolMessageParam[];
+    userContent: ChatCompletionContentPart[];
+    hasToolResults: boolean;
+    hasOrdinaryUserContent: boolean;
+  } {
+    const toolMessages: ChatCompletionToolMessageParam[] = [];
+    const userContent: ChatCompletionContentPart[] = [];
+    let hasToolResults = false;
+    let hasOrdinaryUserContent = false;
+
+    for (const part of message.content) {
+      if (
+        part instanceof vscode.LanguageModelToolResultPart ||
+        part instanceof vscode.LanguageModelToolResultPart2
+      ) {
+        hasToolResults = true;
+        const converted = this.convertToolResultPart(part);
+        toolMessages.push(converted.message);
+        userContent.push(...converted.images);
+        continue;
+      }
+
+      const converted = this.convertPart(message.role, part) as
+        | ChatCompletionUserMessageParam
+        | undefined;
+      if (!converted) {
+        continue;
+      }
+      hasOrdinaryUserContent = true;
+
+      if (typeof converted.content === 'string') {
+        userContent.push({ type: 'text', text: converted.content });
+      } else {
+        userContent.push(...converted.content);
+      }
+    }
+
+    return {
+      toolMessages,
+      userContent,
+      hasToolResults,
+      hasOrdinaryUserContent,
+    };
+  }
+
+  private convertToolResultPart(
+    part:
+      | vscode.LanguageModelToolResultPart
+      | vscode.LanguageModelToolResultPart2,
+  ): {
+    message: ChatCompletionToolMessageParam;
+    images: ChatCompletionContentPart[];
+  } {
+    const textContent: ChatCompletionContentPartText[] = [];
+    const images: ChatCompletionContentPart[] = [];
+
+    for (const contentPart of part.content) {
+      if (contentPart instanceof vscode.LanguageModelTextPart) {
+        if (contentPart.value.trim()) {
+          textContent.push({ type: 'text', text: contentPart.value });
+        }
+        continue;
+      }
+
+      if (contentPart instanceof vscode.LanguageModelDataPart) {
+        if (
+          isCacheControlMarker(contentPart) ||
+          isInternalMarker(contentPart) ||
+          isUsageMarker(contentPart)
+        ) {
+          continue;
+        }
+
+        if (isImageMarker(contentPart)) {
+          const mimeType = normalizeImageMimeType(contentPart.mimeType);
+          if (!mimeType) {
+            throw new Error(
+              `Unsupported image mime type for provider: ${contentPart.mimeType}`,
+            );
+          }
+          images.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${mimeType};base64,${Buffer.from(
+                contentPart.data,
+              ).toString('base64')}`,
+            },
+          });
+          continue;
+        }
+
+        throw new Error(
+          `Unsupported from_tool_result message LanguageModelDataPart mime type: ${contentPart.mimeType}`,
+        );
+      }
+
+      throw new Error(
+        'Unsupported from_tool_result message part type encountered',
+      );
+    }
+
+    return {
+      message: {
+        role: 'tool',
+        content:
+          textContent.length > 1
+            ? textContent
+            : textContent.length > 0
+              ? textContent[0].text
+              : '',
+        tool_call_id: part.callId,
+      },
+      images,
+    };
   }
 
   private applyCacheControl(messages: ChatCompletionMessageParam[]): void {
@@ -434,6 +584,7 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
     | ChatCompletionUserMessageParam
     | ChatCompletionSystemMessageParam
     | ChatCompletionAssistantMessageParam
+    | ChatCompletionMessageParam[]
     | ChatCompletionContentPartText[]
     | undefined {
     if (part == null) {
@@ -578,25 +729,13 @@ export class OpenAIChatCompletionProvider implements ApiProvider {
       if (role !== vscode.LanguageModelChatMessageRole.User) {
         throw new Error('Tool result parts can only appear in user messages');
       }
-      const content = part.content
-        .map(
-          (v) =>
-            this.convertPart('from_tool_result', v) as
-              | ChatCompletionContentPartText[]
-              | undefined,
-        )
-        .filter((v) => v !== undefined)
-        .flat();
-      return {
-        role: 'tool',
-        content:
-          content.length > 1
-            ? content
-            : content.length > 0
-              ? content[0].text
-              : '',
-        tool_call_id: part.callId,
-      };
+      const converted = this.convertToolResultPart(part);
+      return converted.images.length > 0
+        ? [
+            converted.message,
+            { role: 'user', content: converted.images },
+          ]
+        : converted.message;
     } else {
       throw new Error(`Unsupported ${role} message part type encountered`);
     }

--- a/test/unit/deepseek-vision-message-conversion.test.ts
+++ b/test/unit/deepseek-vision-message-conversion.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LanguageModelChatRequestMessage } from 'vscode';
+
+vi.mock('vscode', () => {
+  class LanguageModelDataPart {
+    constructor(
+      readonly data: Uint8Array,
+      readonly mimeType: string,
+    ) {}
+  }
+
+  class LanguageModelTextPart {
+    constructor(readonly value: string) {}
+  }
+
+  class LanguageModelThinkingPart {
+    constructor(readonly value: string | readonly string[]) {}
+  }
+
+  class LanguageModelToolCallPart {
+    constructor(
+      readonly callId: string,
+      readonly name: string,
+      readonly input: object,
+    ) {}
+  }
+
+  class LanguageModelToolResultPart {
+    constructor(
+      readonly callId: string,
+      readonly content: unknown[],
+    ) {}
+  }
+
+  class LanguageModelToolResultPart2 extends LanguageModelToolResultPart {}
+
+  return {
+    LanguageModelChatMessageRole: { System: 1, User: 2, Assistant: 3 },
+    LanguageModelDataPart,
+    LanguageModelTextPart,
+    LanguageModelThinkingPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelToolResultPart2,
+  };
+});
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => undefined,
+}));
+
+vi.mock('../../src/client/types', () => ({
+  ENCRYPTED_THINKING_PLACEHOLDER: 'Encrypted thinking...',
+}));
+
+vi.mock('../../src/client/definitions', () => ({
+  FeatureId: {},
+}));
+
+vi.mock('../../src/model-id-utils', () => ({
+  getBaseModelId: (id: string) => id,
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  buildBaseUrl: (baseUrl: string) => baseUrl,
+  isFeatureSupportedByProvider: () => false,
+}));
+
+vi.mock('../../src/utils', () => ({
+  DEFAULT_CONTEXT_CACHE_TTL_SECONDS: 300,
+  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
+    connection: 10_000,
+    response: 300_000,
+  },
+  decodeStatefulMarkerPart: (
+    _expectedIdentity: string,
+    _modelId: string,
+    part: { readonly data: Uint8Array },
+  ) => JSON.parse(Buffer.from(part.data).toString('utf8')),
+  isCacheControlMarker: () => false,
+  isImageMarker: (part: { readonly mimeType: string }) =>
+    part.mimeType.startsWith('image/'),
+  isInternalMarker: (part: { readonly mimeType: string }) =>
+    part.mimeType === 'stateful_marker',
+  isRawBaseUrlEnabled: () => false,
+  isUsageMarker: () => false,
+  normalizeImageMimeType: (mimeType: string) =>
+    mimeType === 'image/png' ? mimeType : undefined,
+  tryNormalizeCopilotUsage: () => undefined,
+}));
+
+import * as vscode from 'vscode';
+import { OpenAIChatCompletionProvider } from '../../src/client/openai/chat-completion-client';
+
+class TestDeepSeekChatProvider extends OpenAIChatCompletionProvider {
+  convertForRequest(messages: readonly LanguageModelChatRequestMessage[]) {
+    return this.convertMessages(
+      'provider/deepseek-v4-flash-vision-exp',
+      messages,
+      false,
+      'none',
+      'deepseek-provider-identity',
+    );
+  }
+}
+
+function userMessage(
+  content: LanguageModelChatRequestMessage['content'],
+): LanguageModelChatRequestMessage {
+  return {
+    role: vscode.LanguageModelChatMessageRole.User,
+    name: undefined,
+    content,
+  };
+}
+
+function imagePart(byte: number): vscode.LanguageModelDataPart {
+  return new vscode.LanguageModelDataPart(
+    new Uint8Array([byte]),
+    'image/png',
+  );
+}
+
+function toolResult(
+  callId: string,
+  content: unknown[],
+): vscode.LanguageModelToolResultPart2 {
+  return new vscode.LanguageModelToolResultPart2(callId, content);
+}
+
+function assistantToolRound(callIds: readonly string[]): {
+  message: LanguageModelChatRequestMessage;
+  raw: {
+    role: 'assistant';
+    content: null;
+    tool_calls: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }>;
+  };
+} {
+  const toolCalls = callIds.map((callId) => ({
+    id: callId,
+    type: 'function' as const,
+    function: { name: `tool_${callId}`, arguments: '{}' },
+  }));
+  const raw = {
+    role: 'assistant' as const,
+    content: null,
+    tool_calls: toolCalls,
+  };
+  const marker = new vscode.LanguageModelDataPart(
+    Buffer.from(JSON.stringify({ data: raw })),
+    'stateful_marker',
+  );
+
+  return {
+    message: {
+      role: vscode.LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: [
+        ...callIds.map(
+          (callId) =>
+            new vscode.LanguageModelToolCallPart(
+              callId,
+              `tool_${callId}`,
+              {},
+            ),
+        ),
+        marker,
+      ],
+    },
+    raw,
+  };
+}
+
+const provider = new TestDeepSeekChatProvider({
+  type: 'openai-chat-completion',
+  name: 'DeepSeek',
+  baseUrl: 'https://api.deepseek.com',
+  models: [],
+});
+
+describe('DeepSeek vision Chat Completions message conversion', () => {
+  it('keeps text and image blocks in one user message', () => {
+    const converted = provider.convertForRequest([
+      userMessage([
+        new vscode.LanguageModelTextPart('Inspect this image.'),
+        new vscode.LanguageModelDataPart(
+          new Uint8Array([1, 2, 3]),
+          'image/png',
+        ),
+      ]),
+    ]);
+
+    expect(converted).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Inspect this image.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQID' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('moves tool-result images into a typed user content block', () => {
+    const converted = provider.convertForRequest([
+      userMessage([
+        new vscode.LanguageModelToolResultPart2('call-1', [
+          new vscode.LanguageModelTextPart('Screenshot captured.'),
+          new vscode.LanguageModelDataPart(
+            new Uint8Array([1, 2, 3]),
+            'image/png',
+          ),
+        ]),
+      ]),
+    ]);
+
+    expect(converted).toEqual([
+      {
+        role: 'tool',
+        content: 'Screenshot captured.',
+        tool_call_id: 'call-1',
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQID' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('emits every parallel tool result before their ordered images', () => {
+    const assistant = assistantToolRound(['call-1', 'call-2']);
+    const converted = provider.convertForRequest([
+      assistant.message,
+      userMessage([
+        toolResult('call-1', [
+          new vscode.LanguageModelTextPart('First result.'),
+          imagePart(1),
+          new vscode.LanguageModelTextPart('First result tail.'),
+          imagePart(2),
+        ]),
+      ]),
+      userMessage([
+        toolResult('call-2', [
+          imagePart(3),
+          new vscode.LanguageModelTextPart('Second result.'),
+        ]),
+      ]),
+      userMessage([
+        new vscode.LanguageModelTextPart('Next ordinary request.'),
+        imagePart(4),
+      ]),
+    ]);
+
+    expect(converted).toEqual([
+      assistant.raw,
+      {
+        role: 'tool',
+        content: [
+          { type: 'text', text: 'First result.' },
+          { type: 'text', text: 'First result tail.' },
+        ],
+        tool_call_id: 'call-1',
+      },
+      {
+        role: 'tool',
+        content: 'Second result.',
+        tool_call_id: 'call-2',
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQ==' },
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,Ag==' },
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,Aw==' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Next ordinary request.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,BA==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps ordinary user messages as hard tool-result boundaries', () => {
+    const assistant = assistantToolRound(['call-1', 'call-2']);
+    const converted = provider.convertForRequest([
+      assistant.message,
+      userMessage([toolResult('call-1', [imagePart(1)])]),
+      userMessage([new vscode.LanguageModelTextPart('Do not reorder me.')]),
+      userMessage([toolResult('call-2', [imagePart(2)])]),
+    ]);
+
+    expect(converted).toEqual([
+      assistant.raw,
+      { role: 'tool', content: '', tool_call_id: 'call-1' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQ==' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Do not reorder me.' }],
+      },
+      { role: 'tool', content: '', tool_call_id: 'call-2' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,Ag==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('groups pure-text and image-only tool results without losing either', () => {
+    const converted = provider.convertForRequest([
+      userMessage([
+        toolResult('call-text', [
+          new vscode.LanguageModelTextPart('Text-only result.'),
+        ]),
+      ]),
+      userMessage([toolResult('call-image', [imagePart(1), imagePart(2)])]),
+    ]);
+
+    expect(converted).toEqual([
+      {
+        role: 'tool',
+        content: 'Text-only result.',
+        tool_call_id: 'call-text',
+      },
+      { role: 'tool', content: '', tool_call_id: 'call-image' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQ==' },
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,Ag==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps mixed content from one tool-result user message together', () => {
+    const converted = provider.convertForRequest([
+      userMessage([
+        toolResult('call-1', [
+          new vscode.LanguageModelTextPart('Tool text.'),
+          imagePart(1),
+        ]),
+        new vscode.LanguageModelTextPart('User follow-up.'),
+        imagePart(2),
+      ]),
+    ]);
+
+    expect(converted).toEqual([
+      { role: 'tool', content: 'Tool text.', tool_call_id: 'call-1' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AQ==' },
+          },
+          { type: 'text', text: 'User follow-up.' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,Ag==' },
+          },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- keep text and image blocks from one VS Code user turn in one OpenAI Chat Completions user message
- serialize image-bearing tool results as valid tool messages followed by typed user image blocks
- batch consecutive parallel ToolResult user messages so every tool response is emitted before their deferred images
- preserve tool_call_id values, tool text, image order, and ordinary user-message boundaries

## Root cause

The Chat Completions converter recursively handled an image inside LanguageModelToolResultPart as a complete user message. It then inserted that `{ role, content }` object into `tool.content[]`, where the API expects typed content blocks. DeepSeek rejected the malformed nested object with `missing field type`.

Moving each image to an adjacent user message fixed the malformed block for a single result, but parallel tool results arrive as consecutive independent VS Code user messages. Emitting an image user message after the first tool result could interrupt the required sequence before the remaining tool_call_id responses. The converter now batches each consecutive tool-result round, emits all tool messages first, and then emits the ordered image blocks as one user message. Normal user content and non-user roles close the batch.

## Validation
- `npm test` (114 files, 1369 tests passed)
- `npx tsc -p . --noEmit`
- `npx tsc -p test/tsconfig.json --noEmit`
- `git diff --check`
- regression coverage includes direct text plus image input, image-bearing tool results, two parallel tool calls returned in separate messages, pure-text and image-only results, multipart ordering, mixed user content, and missing or late result boundaries

Fixes #312