### PR TITLE
feat: add Command Code provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ You can select the `Change All Built-in Utility Models` button to update all `â˜
 | [Google AI Studio (Gemini API)](https://ai.google.dev/aistudio)                              | `google-ai-studio`       | `/v1beta/models:generateContent` | Automatically detect the version number suffix.                                     |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai)                                       | `google-vertex-ai`       | `/v1beta/models:generateContent` | Provide different base URL based on authentication.                                 |
 | [Anthropic Messages API](https://platform.claude.com/docs/en/api/typescript/messages/create) | `anthropic`              | `/v1/messages`                   | Automatically removes duplicated `/v1` suffix.                                      |
+| [Command Code](https://commandcode.ai/docs/provider)                                        | `command-code`           | `/provider/v1`                   | Official API with automatic model synchronization.                                  |
 | [Ollama Chat API](https://docs.ollama.com/api/chat)                                          | `ollama`                 | `/api/chat`                      | Automatically removes duplicated `/api` suffix.                                     |
 | [Zed Cloud API](https://zed.dev/)                                                            | `zed`                    | `/completions`                   | Native sign-in, organization-scoped models, and Edit Prediction v3/v4.              |
 
@@ -873,6 +874,7 @@ The providers listed below support [One-Click Configuration](#one-click-configur
 | [Atlas Cloud](https://www.atlascloud.ai/docs/en/models/llm)                                           |                                                                                      |                            |
 | [AIHubMix](https://aihubmix.com/)                                                                      |                                                                                      |                            |       âœ…        |
 | [Cerebras](https://www.cerebras.ai/)                                                                   | <li>ReasoningField <li>DisableReasoningParam <li>ClearThinking                       | [Details](#cerebras)       |
+| [Command Code](https://commandcode.ai/docs/provider)                                                   | <li>Automatic official model synchronization                                        |                            |
 | [OpenCode Zen (OpenAI Chat Completion)](https://opencode.ai/)                                          | <li>ReasoningContent                                                                 | [Details](#opencode-zen)   |
 | [OpenCode Zen (OpenAI Responses)](https://opencode.ai/)                                                | <li>ReasoningContent                                                                 | [Details](#opencode-zen)   |
 | [OpenCode Zen (Anthropic Messages)](https://opencode.ai/)                                              | <li>InterleavedThinking <li>FineGrainedToolStreaming                                 | [Details](#opencode-zen)   |
@@ -987,6 +989,11 @@ Long-Term Free Quotas:
   - GPT-OSS-120B
   - Qwen 3 235B Instruct
   - ...
+
+#### Command Code
+
+- One provider configuration and API key connect to Command Code's official API, and the official model catalog is synchronized automatically.
+- Provider-level and model-level request overrides are forwarded when supported by Command Code.
 
 #### Nvidia
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -844,6 +844,7 @@ vscode://SmallMain.vscode-unify-chat-provider/import-config?config=<input>&auth=
 | [Google AI Studio (Gemini API)](https://ai.google.dev/aistudio)                              | `google-ai-studio`       | `/v1beta/models:generateContent` | 自动检测并处理版本号后缀。                |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai)                                       | `google-vertex-ai`       | `/v1beta/models:generateContent` | 根据身份验证自动使用不同的基础 URL。      |
 | [Anthropic Messages API](https://platform.claude.com/docs/en/api/typescript/messages/create) | `anthropic`              | `/v1/messages`                   | 自动移除重复的 `/v1` 后缀。               |
+| [Command Code](https://commandcode.ai/docs/provider)                                        | `command-code`           | `/provider/v1`                   | 官方 API，支持自动同步模型。                 |
 | [Ollama Chat API](https://docs.ollama.com/api/chat)                                          | `ollama`                 | `/api/chat`                      | 自动移除重复的 `/api` 后缀。              |
 | [Zed Cloud API](https://zed.dev/)                                                            | `zed`                    | `/completions`                   | 原生登录、组织模型与 Edit Prediction v3/v4。 |
 
@@ -873,6 +874,7 @@ vscode://SmallMain.vscode-unify-chat-provider/import-config?config=<input>&auth=
 | [Atlas Cloud](https://www.atlascloud.ai/docs/zh/models/llm)                                   |                                                                                      |                       |
 | [AIHubMix](https://aihubmix.com/)                                                             |                                                                                      |                       |    ✅    |
 | [Cerebras](https://www.cerebras.ai/)                                                          | <li>ReasoningField <li>DisableReasoningParam <li>ClearThinking                       | [详情](#cerebras)     |
+| [Command Code](https://commandcode.ai/docs/provider)                                          | <li>自动同步官方模型                                                                 |                       |
 | [OpenCode Zen (OpenAI Chat Completion)](https://opencode.ai/)                                 | <li>ReasoningContent                                                                 | [详情](#opencode-zen) |
 | [OpenCode Zen (OpenAI Responses)](https://opencode.ai/)                                       | <li>ReasoningContent                                                                 | [详情](#opencode-zen) |
 | [OpenCode Zen (Anthropic Messages)](https://opencode.ai/)                                     | <li>InterleavedThinking <li>FineGrainedToolStreaming                                 | [详情](#opencode-zen) |
@@ -987,6 +989,11 @@ vscode://SmallMain.vscode-unify-chat-provider/import-config?config=<input>&auth=
   - GPT-OSS-120B
   - Qwen 3 235B Instruct
   - ...
+
+#### Command Code
+
+- 一份供应商配置和一个 API Key 即可连接 Command Code 官方 API，并自动同步官方模型目录。
+- 供应商级和模型级请求覆盖会在 Command Code 支持时转发。
 
 #### 英伟达
 

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -329,6 +329,8 @@
   "Hugging Face (Inference Providers)": "Hugging Face (Inference Providers)",
   "OpenRouter": "OpenRouter",
   "Cerebras": "Cerebras",
+  "Command Code": "Command Code",
+  "Official API with automatic model synchronization": "Official API with automatic model synchronization",
   "OpenCode Zen (OpenAI Chat Completion)": "OpenCode Zen (OpenAI Chat Completion)",
   "OpenCode Zen (OpenAI Responses)": "OpenCode Zen (OpenAI Responses)",
   "OpenCode Zen (Anthropic Messages)": "OpenCode Zen (Anthropic Messages)",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -329,6 +329,8 @@
   "Hugging Face (Inference Providers)": "Hugging Face (Inference Providers)",
   "OpenRouter": "OpenRouter",
   "Cerebras": "Cerebras",
+  "Command Code": "Command Code",
+  "Official API with automatic model synchronization": "支持自动同步模型的官方 API",
   "OpenCode Zen (OpenAI Chat Completion)": "OpenCode Zen (OpenAI Chat Completion)",
   "OpenCode Zen (OpenAI Responses)": "OpenCode Zen (OpenAI Responses)",
   "OpenCode Zen (Anthropic Messages)": "OpenCode Zen (Anthropic Messages)",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "oai",
     "openai",
     "anthropic",
+    "command-code",
     "gemini",
     "ollama",
     "deepseek",
@@ -636,7 +637,8 @@
                   "xai-grok-build",
                   "ollama",
                   "claude-code",
-                  "zed"
+                  "zed",
+                  "command-code"
                 ],
                 "enumDescriptions": [
                   "%configuration.endpoints.type.enumDescriptions.0%",
@@ -651,7 +653,8 @@
                   "%configuration.endpoints.type.enumDescriptions.11%",
                   "%configuration.endpoints.type.enumDescriptions.5%",
                   "%configuration.endpoints.type.enumDescriptions.9%",
-                  "%configuration.endpoints.type.enumDescriptions.12%"
+                  "%configuration.endpoints.type.enumDescriptions.12%",
+                  "%configuration.endpoints.type.enumDescriptions.13%"
                 ]
               },
               "name": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -92,6 +92,7 @@
   "configuration.endpoints.type.enumDescriptions.10": "GitHub Copilot",
   "configuration.endpoints.type.enumDescriptions.11": "xAI Grok Build",
   "configuration.endpoints.type.enumDescriptions.12": "Zed Cloud Chat wrapper and model discovery API",
+  "configuration.endpoints.type.enumDescriptions.13": "Command Code API with automatic model synchronization",
   "configuration.endpoints.name.description": "Display name for this provider.",
   "configuration.endpoints.baseUrl.description": "API base URL (e.g., https://api.anthropic.com).",
   "configuration.endpoints.useRawBaseUrl.description": "Whether to disable automatic URL normalization, including provider-specific URL handling such as appending /v1 or stripping suffixes.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -92,6 +92,7 @@
   "configuration.endpoints.type.enumDescriptions.10": "GitHub Copilot",
   "configuration.endpoints.type.enumDescriptions.11": "xAI Grok Build",
   "configuration.endpoints.type.enumDescriptions.12": "Zed Cloud Chat 包装与模型发现 API",
+  "configuration.endpoints.type.enumDescriptions.13": "Command Code API，支持自动同步模型",
   "configuration.endpoints.name.description": "此供应商的显示名称。",
   "configuration.endpoints.baseUrl.description": "API 基础 URL（例如：https://api.anthropic.com）。",
   "configuration.endpoints.useRawBaseUrl.description": "是否禁用自动规范化 URL，将禁用追加 /v1 或移除后缀等供应商特定 URL 处理。",

--- a/src/client/command-code/protocol.ts
+++ b/src/client/command-code/protocol.ts
@@ -1,0 +1,38 @@
+import { getBaseModelId } from '../../model-id-utils';
+import type { ModelConfig } from '../../types';
+
+export type CommandCodeProtocol =
+  | 'anthropic-messages'
+  | 'openai-chat-completions';
+
+function normalizedIdentityTokens(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  // Preserve identity boundaries before case folding, including CamelCase and
+  // compact version forms such as ClaudeSonnet and claude3.
+  const boundarySeparated = value
+    .normalize('NFKC')
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Za-z])([0-9])/g, '$1 $2')
+    .replace(/([0-9])([A-Za-z])/g, '$1 $2');
+  return boundarySeparated.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+function hasAnthropicIdentity(value: string | undefined): boolean {
+  return normalizedIdentityTokens(value).some(
+    (token) => token === 'anthropic' || token === 'claude',
+  );
+}
+
+export function resolveCommandCodeProtocol(
+  model: Pick<ModelConfig, 'id' | 'family' | 'name'>,
+): CommandCodeProtocol {
+  const baseId = getBaseModelId(model.id);
+  return [baseId, model.family, model.name].some(hasAnthropicIdentity)
+    ? 'anthropic-messages'
+    : 'openai-chat-completions';
+}

--- a/src/client/command-code/provider.ts
+++ b/src/client/command-code/provider.ts
@@ -1,0 +1,251 @@
+import type {
+  CancellationToken,
+  LanguageModelChatRequestMessage,
+  LanguageModelResponsePart2,
+  ProvideLanguageModelChatResponseOptions,
+} from 'vscode';
+import type { AuthTokenInfo, AuthTokenRefresh } from '../../auth/types';
+import { createSimpleHttpLogger } from '../../logger';
+import type { RequestLogger } from '../../logger';
+import type { ChatRequestTrace, ModelConfig, ProviderConfig } from '../../types';
+import {
+  DEFAULT_NORMAL_TIMEOUT_CONFIG,
+  resolveChatNetwork,
+} from '../../utils';
+import { AnthropicProvider } from '../anthropic/client';
+import type {
+  ApiProvider,
+  EmptyChatResponsePolicy,
+} from '../interface';
+import { OpenAIChatCompletionProvider } from '../openai/chat-completion-client';
+import {
+  createCustomFetch,
+  getToken,
+  getTokenType,
+  getUnifiedUserAgent,
+  mergeHeaders,
+  setUserAgentHeader,
+} from '../utils';
+import { resolveCommandCodeProtocol } from './protocol';
+export {
+  resolveCommandCodeProtocol,
+  type CommandCodeProtocol,
+} from './protocol';
+
+export const COMMAND_CODE_API_BASE_URL =
+  'https://api.commandcode.ai/provider/v1';
+export const COMMAND_CODE_MODELS_URL = `${COMMAND_CODE_API_BASE_URL}/models`;
+export const COMMAND_CODE_MESSAGES_URL = `${COMMAND_CODE_API_BASE_URL}/messages`;
+export const COMMAND_CODE_CHAT_COMPLETIONS_URL =
+  `${COMMAND_CODE_API_BASE_URL}/chat/completions`;
+
+export interface CommandCodeDelegateConfigs {
+  readonly anthropic: ProviderConfig;
+  readonly openAI: ProviderConfig;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireNonEmptyString(
+  record: Record<string, unknown>,
+  key: string,
+  location: string,
+): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(
+      `Failed to get available models: ${location}.${key} must be a non-empty string`,
+    );
+  }
+  return value.trim();
+}
+
+function requireNonNegativeInteger(
+  record: Record<string, unknown>,
+  key: string,
+  location: string,
+): number {
+  const value = record[key];
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 0
+  ) {
+    throw new Error(
+      `Failed to get available models: ${location}.${key} must be a non-negative integer`,
+    );
+  }
+  return value;
+}
+
+function requirePositiveInteger(
+  record: Record<string, unknown>,
+  key: string,
+  location: string,
+): number {
+  const value = record[key];
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value <= 0
+  ) {
+    throw new Error(
+      `Failed to get available models: ${location}.${key} must be a positive integer`,
+    );
+  }
+  return value;
+}
+
+export function parseCommandCodeModelsResponse(raw: unknown): ModelConfig[] {
+  if (!isRecord(raw) || raw['object'] !== 'list' || !Array.isArray(raw['data'])) {
+    throw new Error(
+      'Failed to get available models: unexpected Command Code catalog response',
+    );
+  }
+
+  return raw['data'].map((value, index) => {
+    const location = `data[${index}]`;
+    if (!isRecord(value) || value['object'] !== 'model') {
+      throw new Error(
+        `Failed to get available models: ${location}.object must be "model"`,
+      );
+    }
+
+    const id = requireNonEmptyString(value, 'id', location);
+    const name = requireNonEmptyString(value, 'name', location);
+    requireNonNegativeInteger(value, 'created', location);
+    requireNonEmptyString(value, 'owned_by', location);
+    const contextLength = requirePositiveInteger(
+      value,
+      'context_length',
+      location,
+    );
+
+    return {
+      id,
+      name,
+      maxInputTokens: contextLength,
+    };
+  });
+}
+
+export function createCommandCodeDelegateConfigs(
+  config: ProviderConfig,
+): CommandCodeDelegateConfigs {
+  const shared: ProviderConfig = {
+    ...config,
+    baseUrl: COMMAND_CODE_API_BASE_URL,
+    useRawBaseUrl: false,
+  };
+  return {
+    anthropic: { ...shared, type: 'anthropic' },
+    openAI: { ...shared, type: 'openai-chat-completion' },
+  };
+}
+
+export class CommandCodeProvider implements ApiProvider {
+  private readonly providerConfig: ProviderConfig;
+  private readonly anthropicProvider: ApiProvider;
+  private readonly openAIProvider: ApiProvider;
+
+  constructor(config: ProviderConfig) {
+    const delegateConfigs = createCommandCodeDelegateConfigs(config);
+    this.providerConfig = {
+      ...config,
+      baseUrl: COMMAND_CODE_API_BASE_URL,
+      useRawBaseUrl: false,
+    };
+    this.anthropicProvider = new AnthropicProvider(delegateConfigs.anthropic);
+    this.openAIProvider = new OpenAIChatCompletionProvider(
+      delegateConfigs.openAI,
+    );
+  }
+
+  getEmptyChatResponsePolicy(model: ModelConfig): EmptyChatResponsePolicy {
+    return resolveCommandCodeProtocol(model) === 'anthropic-messages'
+      ? 'success'
+      : 'retry';
+  }
+
+  async *streamChat(
+    encodedModelId: string,
+    model: ModelConfig,
+    messages: readonly LanguageModelChatRequestMessage[],
+    options: ProvideLanguageModelChatResponseOptions,
+    requestTrace: ChatRequestTrace,
+    token: CancellationToken,
+    logger: RequestLogger,
+    credential: AuthTokenInfo,
+    refreshCredential?: AuthTokenRefresh,
+  ): AsyncGenerator<LanguageModelResponsePart2> {
+    const provider =
+      resolveCommandCodeProtocol(model) === 'anthropic-messages'
+        ? this.anthropicProvider
+        : this.openAIProvider;
+    yield* provider.streamChat(
+      encodedModelId,
+      model,
+      messages,
+      options,
+      requestTrace,
+      token,
+      logger,
+      credential,
+      refreshCredential,
+    );
+  }
+
+  estimateTokenCount(text: string): number {
+    return this.openAIProvider.estimateTokenCount(text);
+  }
+
+  async getAvailableModels(
+    credential: AuthTokenInfo,
+    _refreshCredential?: AuthTokenRefresh,
+    signal?: AbortSignal,
+  ): Promise<ModelConfig[]> {
+    const logger = createSimpleHttpLogger({
+      purpose: 'Get Available Models',
+      providerName: this.providerConfig.name,
+      providerType: this.providerConfig.type,
+    });
+    const network = resolveChatNetwork(this.providerConfig);
+    const timeout = network.timeout ?? DEFAULT_NORMAL_TIMEOUT_CONFIG;
+    const fetchWithNetwork = createCustomFetch({
+      connectionTimeoutMs: timeout.connection,
+      responseTimeoutMs: timeout.response,
+      logger,
+      retryConfig: network.retry,
+      proxy: network.proxy,
+      type: 'normal',
+    });
+    const token = getToken(credential);
+    const headers = mergeHeaders(token, this.providerConfig.extraHeaders);
+    headers['Accept'] = 'application/json';
+    setUserAgentHeader(headers, getUnifiedUserAgent());
+    if (token) {
+      headers['Authorization'] =
+        `${getTokenType(credential) ?? 'Bearer'} ${token}`;
+    }
+
+    try {
+      const response = await fetchWithNetwork(COMMAND_CODE_MODELS_URL, {
+        method: 'GET',
+        headers,
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to get available models: HTTP ${response.status}`,
+        );
+      }
+      const raw: unknown = await response.json();
+      return parseCommandCodeModelsResponse(raw);
+    } catch (error) {
+      logger.error(error);
+      throw error;
+    }
+  }
+}

--- a/src/client/definitions.ts
+++ b/src/client/definitions.ts
@@ -14,6 +14,7 @@ import { OpenAICodexProvider } from './openai/codex-client';
 import { OpenAIResponsesProvider } from './openai/responses-client';
 import { XaiGrokBuildProvider } from './xai/grok-build-client';
 import { ZedProvider } from './zed/provider';
+import { CommandCodeProvider } from './command-code/provider';
 import { Feature } from './types';
 import { matchProvider, matchModelFamily } from './utils';
 
@@ -25,6 +26,7 @@ export type ProviderType =
   | 'google-antigravity'
   | 'google-gemini-cli'
   | 'github-copilot'
+  | 'command-code'
   | 'zed'
   | 'openai-chat-completion'
   | 'openai-codex'
@@ -39,6 +41,14 @@ export const PROVIDER_TYPES: Record<ProviderType, ProviderDefinition> = {
     description: '/v1/messages',
     category: 'General',
     class: AnthropicProvider,
+    emptyChatResponsePolicy: 'success',
+  },
+  'command-code': {
+    type: 'command-code',
+    label: t('Command Code'),
+    description: t('Official API with automatic model synchronization'),
+    category: 'General',
+    class: CommandCodeProvider,
   },
   'google-ai-studio': {
     type: 'google-ai-studio',

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -7,7 +7,9 @@ import type {
 import type { ChatRequestTrace, ModelConfig, ProviderConfig } from '../types';
 import type { RequestLogger } from '../logger';
 import type { AuthTokenInfo, AuthTokenRefresh } from '../auth/types';
-import { ProviderType } from './definitions';
+import type { ProviderType } from './definitions';
+
+export type EmptyChatResponsePolicy = 'retry' | 'success';
 
 export interface ProviderDefinition {
   type: ProviderType;
@@ -19,6 +21,8 @@ export interface ProviderDefinition {
    */
   category: string;
   class: new (config: ProviderConfig) => ApiProvider;
+  /** How a clean response stream with no public VS Code parts is handled. */
+  emptyChatResponsePolicy?: EmptyChatResponsePolicy;
 }
 
 /**
@@ -46,6 +50,14 @@ export interface ApiProvider {
   estimateTokenCount(text: string): number;
 
   /**
+   * Override the provider definition's empty-stream policy for a model.
+   * Composite providers use this when the effective wire protocol is model-specific.
+   */
+  getEmptyChatResponsePolicy?(
+    model: ModelConfig,
+  ): EmptyChatResponsePolicy;
+
+  /**
    * Get available models from the provider
    * Returns a list of model configurations supported by this API client
    */
@@ -54,4 +66,16 @@ export interface ApiProvider {
     refreshCredential?: AuthTokenRefresh,
     signal?: AbortSignal,
   ): Promise<ModelConfig[]>;
+}
+
+export function resolveEmptyChatResponsePolicy(
+  definition: Pick<ProviderDefinition, 'emptyChatResponsePolicy'>,
+  provider: Pick<ApiProvider, 'getEmptyChatResponsePolicy'>,
+  model: ModelConfig,
+): EmptyChatResponsePolicy {
+  return (
+    provider.getEmptyChatResponsePolicy?.(model) ??
+    definition.emptyChatResponsePolicy ??
+    'retry'
+  );
 }

--- a/src/main-instance/protocol.ts
+++ b/src/main-instance/protocol.ts
@@ -8,7 +8,7 @@ export const PROTOCOL_VERSION = 1 as const;
  * when IPC/RPC message contracts, shared state contracts, or leader/follower
  * behavior become incompatible across extension instances.
  */
-export const MAIN_INSTANCE_COMPATIBILITY_VERSION = 8 as const;
+export const MAIN_INSTANCE_COMPATIBILITY_VERSION = 9 as const;
 
 export type HelloMessage = {
   type: 'hello';

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,7 +4,10 @@ import {
   DEFAULT_MAX_INPUT_TOKENS,
   DEFAULT_MAX_OUTPUT_TOKENS,
 } from './defaults';
-import { ApiProvider } from './client/interface';
+import {
+  ApiProvider,
+  resolveEmptyChatResponsePolicy,
+} from './client/interface';
 import { createRequestLogger } from './logger';
 import {
   ChatRequestTrace,
@@ -18,6 +21,7 @@ import {
   parseVsCodeModelId,
 } from './model-id-utils';
 import { createProvider } from './client/utils';
+import { PROVIDER_TYPES } from './client/definitions';
 import {
   formatProviderBadgeSuffixForModelSelection,
   formatModelTooltipForModelSelection,
@@ -843,7 +847,13 @@ export class UnifyChatService implements vscode.LanguageModelChatProvider {
           // response as an error, so the Anthropic client suppresses all
           // parts in this scenario. We must treat those 0-part responses as
           // successful no-op completions and not retry.
-          if (resolvedProvider.type === 'anthropic') {
+          if (
+            resolveEmptyChatResponsePolicy(
+              PROVIDER_TYPES[resolvedProvider.type],
+              client,
+              resolvedRequestModel,
+            ) === 'success'
+          ) {
             break;
           }
 

--- a/src/well-known/providers.ts
+++ b/src/well-known/providers.ts
@@ -213,6 +213,15 @@ export const WELL_KNOWN_PROVIDERS: WellKnownProviderConfig[] = [
     ],
   },
   {
+    name: 'Command Code',
+    category: 'General',
+    type: 'command-code',
+    baseUrl: 'https://api.commandcode.ai/provider/v1',
+    authTypes: ['api-key'],
+    models: [],
+    autoFetchOfficialModels: true,
+  },
+  {
     name: 'OpenCode Zen (OpenAI Chat Completion)',
     category: 'General',
     type: 'openai-chat-completion',

--- a/test/unit/command-code-config.test.ts
+++ b/test/unit/command-code-config.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  env: {
+    clipboard: {
+      readText: vi.fn(),
+      writeText: vi.fn(),
+    },
+  },
+  l10n: { t: (message: string) => message },
+}));
+
+vi.mock('../../src/config-ops', () => ({
+  MODEL_CONFIG_KEYS: [],
+  PROVIDER_CONFIG_KEYS: [],
+  deepClone: <T>(value: T): T => structuredClone(value),
+  mergePartialByKeys: vi.fn(),
+  withoutKey: vi.fn(),
+}));
+
+import {
+  decodeBase64ToObject,
+  encodeConfigToBase64,
+} from '../../src/ui/base64-config';
+import type { ProviderConfig } from '../../src/types';
+
+describe('Command Code configuration transfer', () => {
+  it('round-trips one provider with shared defaults and model overrides', () => {
+    const config: ProviderConfig = {
+      type: 'command-code',
+      name: 'Command Code',
+      baseUrl: 'https://api.commandcode.ai/provider/v1',
+      transport: 'sse',
+      serviceTier: 'priority',
+      auth: { method: 'api-key', apiKey: '' },
+      extraBody: { shared_provider_option: true },
+      models: [
+        {
+          id: 'opaque-id',
+          name: 'Claude Model With Opaque ID',
+          serviceTier: 'standard',
+          extraBody: { model_option: 'override' },
+        },
+      ],
+      autoFetchOfficialModels: true,
+    };
+
+    const encoded = encodeConfigToBase64(config);
+    const decoded = decodeBase64ToObject<ProviderConfig>(encoded);
+
+    expect(decoded).toEqual(config);
+  });
+});

--- a/test/unit/command-code-provider.test.ts
+++ b/test/unit/command-code-provider.test.ts
@@ -1,0 +1,458 @@
+import type * as vscode from 'vscode';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RequestLogger } from '../../src/logger';
+import type { ChatRequestTrace, ModelConfig, ProviderConfig } from '../../src/types';
+
+const state = vi.hoisted(() => ({
+  anthropicConfigs: [] as unknown[],
+  anthropicGetAvailableModels: vi.fn(),
+  anthropicStreamChat: vi.fn(),
+  fetch: vi.fn(),
+  httpError: vi.fn(),
+  openAIConfigs: [] as unknown[],
+  openAIGetAvailableModels: vi.fn(),
+  openAIEstimateTokenCount: vi.fn((_text: string) => 17),
+  openAIStreamChat: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  env: { language: 'en' },
+  extensions: { getExtension: () => undefined },
+  LanguageModelChatToolMode: { Auto: 1 },
+  l10n: {
+    t: (message: string | { message: string }) =>
+      typeof message === 'string' ? message : message.message,
+  },
+}));
+
+vi.mock('../../src/logger', () => ({
+  createSimpleHttpLogger: () => ({ error: state.httpError }),
+}));
+
+vi.mock('../../src/utils', () => ({
+  DEFAULT_NORMAL_TIMEOUT_CONFIG: {
+    connection: 30_000,
+    response: 30_000,
+  },
+  resolveChatNetwork: () => ({
+    retry: { maxRetries: 0 },
+    proxy: { type: 'direct' },
+  }),
+}));
+
+vi.mock('../../src/client/utils', () => ({
+  createCustomFetch: () => state.fetch,
+  getToken: (credential: { kind: string; token?: string }) =>
+    credential.kind === 'token' ? credential.token : undefined,
+  getTokenType: (credential: { kind: string; tokenType?: string }) =>
+    credential.kind === 'token' ? credential.tokenType : undefined,
+  getUnifiedUserAgent: () => 'ucp/test',
+  matchProvider: (url: string, pattern: string | RegExp) =>
+    typeof pattern === 'string'
+      ? url.includes(pattern.replaceAll('*', ''))
+      : pattern.test(url),
+  mergeHeaders: (
+    _token: string | undefined,
+    ...sources: Array<Record<string, string> | undefined>
+  ) => Object.assign({}, ...sources.filter((source) => source !== undefined)),
+  setUserAgentHeader: (headers: Record<string, string>, value: string) => {
+    headers['User-Agent'] = value;
+  },
+}));
+
+vi.mock('../../src/client/anthropic/client', () => ({
+  AnthropicProvider: class AnthropicProvider {
+    constructor(config: unknown) {
+      state.anthropicConfigs.push(config);
+    }
+
+    async *streamChat(...args: unknown[]): AsyncGenerator<never> {
+      state.anthropicStreamChat(...args);
+    }
+
+    estimateTokenCount(): number {
+      return 13;
+    }
+
+    async getAvailableModels(): Promise<ModelConfig[]> {
+      state.anthropicGetAvailableModels();
+      return [];
+    }
+  },
+}));
+
+vi.mock('../../src/client/openai/chat-completion-client', () => ({
+  OpenAIChatCompletionProvider: class OpenAIChatCompletionProvider {
+    constructor(config: unknown) {
+      state.openAIConfigs.push(config);
+    }
+
+    async *streamChat(...args: unknown[]): AsyncGenerator<never> {
+      state.openAIStreamChat(...args);
+    }
+
+    estimateTokenCount(text: string): number {
+      return state.openAIEstimateTokenCount(text);
+    }
+
+    async getAvailableModels(): Promise<ModelConfig[]> {
+      state.openAIGetAvailableModels();
+      return [];
+    }
+  },
+}));
+
+import {
+  COMMAND_CODE_API_BASE_URL,
+  COMMAND_CODE_CHAT_COMPLETIONS_URL,
+  COMMAND_CODE_MESSAGES_URL,
+  COMMAND_CODE_MODELS_URL,
+  CommandCodeProvider,
+  createCommandCodeDelegateConfigs,
+  parseCommandCodeModelsResponse,
+  resolveCommandCodeProtocol,
+} from '../../src/client/command-code/provider';
+import * as vscodeApi from 'vscode';
+import { resolveEmptyChatResponsePolicy } from '../../src/client/interface';
+import { createVsCodeModelId, parseVsCodeModelId } from '../../src/model-id-utils';
+import { WELL_KNOWN_PROVIDERS } from '../../src/well-known/providers';
+
+function commandCodeConfig(): ProviderConfig {
+  return {
+    type: 'command-code',
+    name: 'Command Code',
+    baseUrl: COMMAND_CODE_API_BASE_URL,
+    useRawBaseUrl: true,
+    transport: 'sse',
+    serviceTier: 'priority',
+    auth: { method: 'api-key', apiKey: 'secret-ref' },
+    extraHeaders: { 'x-cmd-zdr': '1' },
+    extraBody: { shared_provider_option: true },
+    models: [],
+    autoFetchOfficialModels: true,
+  };
+}
+
+function trace(): ChatRequestTrace {
+  return {
+    performance: {
+      tts: 0,
+      ttf: 0,
+      ttft: 0,
+      tps: 0,
+      tl: 0,
+    },
+  };
+}
+
+function cancellationToken(): vscode.CancellationToken {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose: () => undefined }),
+  };
+}
+
+async function consume(source: AsyncIterable<unknown>): Promise<void> {
+  for await (const part of source) {
+    void part;
+  }
+}
+
+beforeEach(() => {
+  state.anthropicConfigs = [];
+  state.anthropicGetAvailableModels.mockReset();
+  state.anthropicStreamChat.mockReset();
+  state.fetch.mockReset();
+  state.httpError.mockReset();
+  state.openAIConfigs = [];
+  state.openAIGetAvailableModels.mockReset();
+  state.openAIEstimateTokenCount.mockClear();
+  state.openAIStreamChat.mockReset();
+});
+
+describe('Command Code provider facade', () => {
+  it('registers one well-known provider and constructs both protocol delegates', () => {
+    const providers = WELL_KNOWN_PROVIDERS.filter(
+      (provider) => provider.name === 'Command Code',
+    );
+    expect(providers).toEqual([
+      expect.objectContaining({
+        type: 'command-code',
+        baseUrl: COMMAND_CODE_API_BASE_URL,
+        authTypes: ['api-key'],
+        models: [],
+        autoFetchOfficialModels: true,
+      }),
+    ]);
+
+    const config = commandCodeConfig();
+    const delegates = createCommandCodeDelegateConfigs(config);
+
+    expect(delegates.openAI).toMatchObject({
+      type: 'openai-chat-completion',
+      baseUrl: COMMAND_CODE_API_BASE_URL,
+      useRawBaseUrl: false,
+      transport: 'sse',
+      serviceTier: 'priority',
+      extraBody: { shared_provider_option: true },
+    });
+    expect(delegates.anthropic).toMatchObject({
+      type: 'anthropic',
+      baseUrl: COMMAND_CODE_API_BASE_URL,
+      useRawBaseUrl: false,
+      transport: 'sse',
+      serviceTier: 'priority',
+      extraBody: { shared_provider_option: true },
+    });
+    expect(delegates.openAI.auth).toBe(config.auth);
+    expect(delegates.anthropic.auth).toBe(config.auth);
+    expect(delegates.openAI.extraHeaders).toBe(config.extraHeaders);
+    expect(delegates.anthropic.extraHeaders).toBe(config.extraHeaders);
+    expect(delegates.openAI.models).toBe(config.models);
+    expect(delegates.anthropic.models).toBe(config.models);
+    expect(`${delegates.openAI.baseUrl}/chat/completions`).toBe(
+      COMMAND_CODE_CHAT_COMPLETIONS_URL,
+    );
+    expect(
+      `${delegates.anthropic.baseUrl.replace(/\/v1$/, '')}/v1/messages`,
+    ).toBe(COMMAND_CODE_MESSAGES_URL);
+
+    new CommandCodeProvider(config);
+    expect(state.openAIConfigs).toEqual([delegates.openAI]);
+    expect(state.anthropicConfigs).toEqual([delegates.anthropic]);
+  });
+
+  it.each([
+    [{ id: 'claude-sonnet-5' }, 'anthropic-messages'],
+    [{ id: 'anthropic/sonnet-next' }, 'anthropic-messages'],
+    [{ id: 'vendor/claude3-model' }, 'anthropic-messages'],
+    [{ id: 'vendor/models/CLAUDE-sonnet-next' }, 'anthropic-messages'],
+    [{ id: 'vendor/models/ClaudeSonnetNext' }, 'anthropic-messages'],
+    [{ id: 'opaque-id', family: 'Anthropic Claude' }, 'anthropic-messages'],
+    [
+      { id: 'opaque-id', name: '  CLAUDE Model With Opaque ID  ' },
+      'anthropic-messages',
+    ],
+    [{ id: 'claudette-code' }, 'openai-chat-completions'],
+    [{ id: 'claudemeter/model' }, 'openai-chat-completions'],
+    [{ id: 'anthropicist/model' }, 'openai-chat-completions'],
+    [{ id: 'deepseek/deepseek-v4-flash' }, 'openai-chat-completions'],
+    [{ id: 'opaque-id', name: 'Unknown Frontier Model' }, 'openai-chat-completions'],
+  ] as const)('routes model identity %o through %s', (model, expected) => {
+    expect(resolveCommandCodeProtocol(model)).toBe(expected);
+  });
+
+  it('forwards every stream argument and preserves model-level overrides', async () => {
+    const provider = new CommandCodeProvider(commandCodeConfig());
+    const claudeModel: ModelConfig = {
+      id: 'opaque-id',
+      name: 'Claude Opaque',
+      serviceTier: 'standard',
+      extraBody: { model_option: 'override' },
+    };
+    const openAIModel: ModelConfig = {
+      id: 'gpt-5.6-sol',
+      serviceTier: 'flex',
+      extraBody: { model_option: 'openai' },
+    };
+    const messages: readonly vscode.LanguageModelChatRequestMessage[] = [];
+    const options: vscode.ProvideLanguageModelChatResponseOptions = {
+      requestInitiator: 'test',
+      toolMode: vscodeApi.LanguageModelChatToolMode.Auto,
+      tools: [],
+    };
+    const requestTrace = trace();
+    const token = cancellationToken();
+    const logger = Object.create(null) as RequestLogger;
+    const credential = {
+      kind: 'token',
+      token: 'command-code-key',
+      tokenType: 'Bearer',
+    } as const;
+    const refreshCredential = vi.fn(async () => credential);
+
+    await consume(
+      provider.streamChat(
+        'Command Code/opaque-id',
+        claudeModel,
+        messages,
+        options,
+        requestTrace,
+        token,
+        logger,
+        credential,
+        refreshCredential,
+      ),
+    );
+    expect(state.anthropicStreamChat).toHaveBeenCalledWith(
+      'Command Code/opaque-id',
+      claudeModel,
+      messages,
+      options,
+      requestTrace,
+      token,
+      logger,
+      credential,
+      refreshCredential,
+    );
+    expect(state.openAIStreamChat).not.toHaveBeenCalled();
+
+    await consume(
+      provider.streamChat(
+        'Command Code/gpt-5.6-sol',
+        openAIModel,
+        messages,
+        options,
+        requestTrace,
+        token,
+        logger,
+        credential,
+        refreshCredential,
+      ),
+    );
+    expect(state.openAIStreamChat).toHaveBeenCalledWith(
+      'Command Code/gpt-5.6-sol',
+      openAIModel,
+      messages,
+      options,
+      requestTrace,
+      token,
+      logger,
+      credential,
+      refreshCredential,
+    );
+    expect(provider.estimateTokenCount('count me')).toBe(17);
+    expect(state.openAIEstimateTokenCount).toHaveBeenCalledWith('count me');
+  });
+
+  it('uses the Anthropic empty-response policy only for Messages models', () => {
+    const provider = new CommandCodeProvider(commandCodeConfig());
+    expect(
+      resolveEmptyChatResponsePolicy({}, provider, {
+        id: 'opaque-id',
+        name: 'Claude Opaque',
+      }),
+    ).toBe('success');
+    expect(
+      resolveEmptyChatResponsePolicy({}, provider, { id: 'gpt-5.6-sol' }),
+    ).toBe('retry');
+    expect(
+      resolveEmptyChatResponsePolicy(
+        { emptyChatResponsePolicy: 'success' },
+        {},
+        { id: 'any-model' },
+      ),
+    ).toBe('success');
+  });
+
+  it('fetches one strict catalog and preserves context_length', async () => {
+    state.fetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          object: 'list',
+          data: [
+            {
+              id: 'opaque-id',
+              object: 'model',
+              created: 1_787_812_951,
+              owned_by: 'command-code',
+              name: 'Claude Opaque',
+              context_length: 1_000_000,
+            },
+            {
+              id: 'gpt-5.6-sol',
+              object: 'model',
+              created: 1_787_812_952,
+              owned_by: 'command-code',
+              name: 'GPT 5.6 Sol',
+              context_length: 400_000,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    const provider = new CommandCodeProvider(commandCodeConfig());
+    const abortController = new AbortController();
+
+    const models = await provider.getAvailableModels(
+      {
+        kind: 'token',
+        token: 'command-code-key',
+        tokenType: 'Bearer',
+      },
+      undefined,
+      abortController.signal,
+    );
+
+    expect(state.fetch).toHaveBeenCalledOnce();
+    expect(state.fetch).toHaveBeenCalledWith(
+      COMMAND_CODE_MODELS_URL,
+      expect.objectContaining({
+        method: 'GET',
+        signal: abortController.signal,
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          Authorization: 'Bearer command-code-key',
+          'User-Agent': 'ucp/test',
+          'x-cmd-zdr': '1',
+        }),
+      }),
+    );
+    expect(state.anthropicGetAvailableModels).not.toHaveBeenCalled();
+    expect(state.openAIGetAvailableModels).not.toHaveBeenCalled();
+    expect(models).toEqual([
+      {
+        id: 'opaque-id',
+        name: 'Claude Opaque',
+        maxInputTokens: 1_000_000,
+      },
+      {
+        id: 'gpt-5.6-sol',
+        name: 'GPT 5.6 Sol',
+        maxInputTokens: 400_000,
+      },
+    ]);
+  });
+
+  it('rejects malformed current catalog fields without requiring supported_endpoints', () => {
+    expect(() =>
+      parseCommandCodeModelsResponse({
+        object: 'list',
+        data: [
+          {
+            id: 'valid-without-supported-endpoints',
+            object: 'model',
+            created: 1,
+            owned_by: 'command-code',
+            name: 'Valid Model',
+            context_length: 128_000,
+          },
+        ],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      parseCommandCodeModelsResponse({
+        object: 'list',
+        data: [
+          {
+            id: 'invalid-context',
+            object: 'model',
+            created: 1,
+            owned_by: 'command-code',
+            name: 'Invalid Model',
+            context_length: '128000',
+          },
+        ],
+      }),
+    ).toThrow('context_length must be a positive integer');
+  });
+
+  it('keeps one provider/model identity for the VS Code UI', () => {
+    const encoded = createVsCodeModelId('Command Code', 'opaque/model');
+    expect(parseVsCodeModelId(encoded)).toEqual({
+      providerName: 'Command Code',
+      modelName: 'opaque/model',
+    });
+  });
+});

--- a/test/unit/completion-api-registry.test.ts
+++ b/test/unit/completion-api-registry.test.ts
@@ -29,11 +29,15 @@ import {
 import type { NativeCompletionApiContext } from '../../src/completion/api/provider';
 import type { CompletionTemplates } from '../../src/types';
 
-function context(templates: CompletionTemplates): NativeCompletionApiContext {
+function context(
+  templates: CompletionTemplates,
+  providerType: NativeCompletionApiContext['provider']['type'] =
+    'openai-chat-completion',
+): NativeCompletionApiContext {
   const model = { id: 'test-model' };
   return {
     provider: {
-      type: 'openai-chat-completion',
+      type: providerType,
       name: 'test-provider',
       baseUrl: 'https://example.test/v1',
       models: [model],
@@ -74,6 +78,15 @@ describe('native Completion API Provider registry', () => {
     const all = nativeCompletionApiProviderRegistry.create(context('all'));
     expect(all?.operations['mercury-edit-2']).toBeDefined();
     expect(all?.operations.codestral).toBeDefined();
+  });
+
+  it('does not treat Command Code as a traditional Completions provider', () => {
+    expect(
+      nativeCompletionApiProviderRegistry.create(context([], 'command-code')),
+    ).toBeUndefined();
+    expect(
+      nativeCompletionApiProviderRegistry.listProviderTypes(),
+    ).not.toContain('command-code');
   });
 
   it('rejects duplicate and empty registrations at startup', () => {

--- a/test/unit/completion-package-schema.test.ts
+++ b/test/unit/completion-package-schema.test.ts
@@ -153,6 +153,7 @@ describe('completion package schemas', () => {
       'provider.type.enumDescriptions',
     );
     expect(values).toContain('zed');
+    expect(values).toContain('command-code');
     expect(values).not.toContain('inception');
     expect(values).not.toContain('mistral');
     expect(descriptions).toHaveLength(values.length);

--- a/test/unit/import-config-uri.test.ts
+++ b/test/unit/import-config-uri.test.ts
@@ -82,8 +82,11 @@ vi.mock('../../src/main-instance', () => ({
 }));
 
 vi.mock('../../src/client/definitions', () => ({
-  PROVIDER_KEYS: ['openai-chat-completion'],
-  PROVIDER_TYPES: { 'openai-chat-completion': {} },
+  PROVIDER_KEYS: ['command-code', 'openai-chat-completion'],
+  PROVIDER_TYPES: {
+    'command-code': {},
+    'openai-chat-completion': {},
+  },
 }));
 
 vi.mock('../../src/utils', () => ({
@@ -146,6 +149,36 @@ describe('ImportConfigUriHandler auth validation', () => {
       token: '{invalid-json}',
     },
   };
+
+  it('preserves the Command Code provider and model identity during import parsing', () => {
+    expect(
+      parseProviderConfigInput({
+        type: 'command-code',
+        name: 'Command Code',
+        baseUrl: 'https://api.commandcode.ai/provider/v1',
+        transport: 'sse',
+        serviceTier: 'priority',
+        extraBody: { shared_provider_option: true },
+        models: [
+          {
+            id: 'opaque-id',
+            name: 'Claude Model With Opaque ID',
+            serviceTier: 'standard',
+            extraBody: { model_option: 'override' },
+          },
+        ],
+      }),
+    ).toMatchObject({
+      type: 'command-code',
+      name: 'Command Code',
+      models: [
+        {
+          id: 'opaque-id',
+          name: 'Claude Model With Opaque ID',
+        },
+      ],
+    });
+  });
 
   it('rejects malformed session tokens in single and array config inputs', () => {
     expect(parseProviderConfigInput(malformedTokenProvider)).toBeUndefined();

--- a/test/unit/main-instance-compatibility.test.ts
+++ b/test/unit/main-instance-compatibility.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const network = vi.hoisted(() => ({
-  welcomeCompatibilityVersion: 8,
+  welcomeCompatibilityVersion: 9,
   welcomeExtensionVersion: 'leader-1.0.0',
   writes: [] as string[],
 }));
@@ -142,7 +142,7 @@ import {
 const coordinators: MainInstanceCoordinator[] = [];
 
 beforeEach(() => {
-  network.welcomeCompatibilityVersion = 8;
+  network.welcomeCompatibilityVersion = 9;
   network.welcomeExtensionVersion = 'leader-1.0.0';
   network.writes = [];
 });
@@ -227,7 +227,7 @@ function hello(
 }
 
 describe('main-instance compatibility handshake', () => {
-  it('accepts a differently-versioned v8 follower at a v8 leader', () => {
+  it('accepts a differently-versioned v9 follower at a v9 leader', () => {
     const coordinator = createCoordinator();
     Reflect.set(coordinator, 'authToken', 'test-token');
     const peer = createLeaderSocket();
@@ -242,18 +242,18 @@ describe('main-instance compatibility handshake', () => {
     expect(response).toMatchObject({
       type: 'welcome',
       protocolVersion: 1,
-      mainInstanceCompatibilityVersion: 8,
+      mainInstanceCompatibilityVersion: 9,
     });
   });
 
-  it('rejects a v7 follower at a v8 leader', () => {
+  it('rejects a v8 follower at a v9 leader', () => {
     const coordinator = createCoordinator();
     Reflect.set(coordinator, 'authToken', 'test-token');
     const peer = createLeaderSocket();
 
     invokePrivate(coordinator, 'handleLeaderSideMessage', [
       peer.socket,
-      hello(7),
+      hello(8),
     ]);
 
     expect(peer.isDestroyed()).toBe(true);
@@ -266,7 +266,7 @@ describe('main-instance compatibility handshake', () => {
     });
   });
 
-  it('connects differently-versioned v8 follower and leader releases', async () => {
+  it('connects differently-versioned v9 follower and leader releases', async () => {
     const coordinator = createCoordinator();
     configureFollower(coordinator);
 
@@ -286,12 +286,12 @@ describe('main-instance compatibility handshake', () => {
     expect(parseMessageLine(network.writes[0] ?? '')).toMatchObject({
       type: 'hello',
       extensionVersion: 'follower-9.9.9',
-      mainInstanceCompatibilityVersion: 8,
+      mainInstanceCompatibilityVersion: 9,
     });
   });
 
-  it('rejects a v7 leader at a v8 follower', async () => {
-    network.welcomeCompatibilityVersion = 7;
+  it('rejects a v8 leader at a v9 follower', async () => {
+    network.welcomeCompatibilityVersion = 8;
     const coordinator = createCoordinator();
     configureFollower(coordinator);
 

--- a/test/unit/main-instance-completion-config.test.ts
+++ b/test/unit/main-instance-completion-config.test.ts
@@ -37,7 +37,11 @@ vi.mock('../../src/main-instance/index', () => ({
 }));
 
 vi.mock('../../src/client/definitions', () => ({
-  PROVIDER_TYPES: { 'openai-chat-completion': {}, zed: {} },
+  PROVIDER_TYPES: {
+    'command-code': {},
+    'openai-chat-completion': {},
+    zed: {},
+  },
 }));
 
 vi.mock('../../src/utils', () => ({
@@ -369,8 +373,47 @@ describe('main-instance completion configuration sync', () => {
     expect(provider.balanceProvider).toEqual({ method: 'sub2api' });
   });
 
-  it('uses compatibility version 8 without changing protocol version 1', () => {
-    expect(MAIN_INSTANCE_COMPATIBILITY_VERSION).toBe(8);
+  it('round-trips the composite Command Code provider contract', () => {
+    const provider = parseProviderConfig(
+      {
+        type: 'command-code',
+        name: 'Command Code',
+        baseUrl: 'https://api.commandcode.ai/provider/v1',
+        useRawBaseUrl: false,
+        transport: 'sse',
+        serviceTier: 'priority',
+        extraBody: { shared_provider_option: true },
+        models: [
+          {
+            id: 'opaque-id',
+            name: 'Claude Opaque',
+            serviceTier: 'standard',
+            extraBody: { model_option: 'override' },
+          },
+        ],
+      },
+      METHOD,
+    );
+
+    expect(provider).toMatchObject({
+      type: 'command-code',
+      name: 'Command Code',
+      transport: 'sse',
+      serviceTier: 'priority',
+      extraBody: { shared_provider_option: true },
+      models: [
+        {
+          id: 'opaque-id',
+          name: 'Claude Opaque',
+          serviceTier: 'standard',
+          extraBody: { model_option: 'override' },
+        },
+      ],
+    });
+  });
+
+  it('uses compatibility version 9 without changing protocol version 1', () => {
+    expect(MAIN_INSTANCE_COMPATIBILITY_VERSION).toBe(9);
     expect(PROTOCOL_VERSION).toBe(1);
   });
 

--- a/test/unit/official-models-manager.test.ts
+++ b/test/unit/official-models-manager.test.ts
@@ -78,6 +78,7 @@ import {
 } from '../../src/official-models-manager';
 import { SecretStore } from '../../src/secret/secret-store';
 import type { ProviderConfig } from '../../src/types';
+import { resolveCommandCodeProtocol } from '../../src/client/command-code/protocol';
 
 const ZED_BINDING_ID = '00000000-0000-4000-8000-000000000103';
 
@@ -123,6 +124,16 @@ function provider(): ProviderConfig {
       bindingId: ZED_BINDING_ID,
       baseUrl: 'https://zed.dev',
     },
+    models: [],
+    autoFetchOfficialModels: true,
+  };
+}
+
+function commandCodeProvider(): ProviderConfig {
+  return {
+    type: 'command-code',
+    name: 'Command Code',
+    baseUrl: 'https://api.commandcode.ai/provider/v1',
     models: [],
     autoFetchOfficialModels: true,
   };
@@ -302,5 +313,53 @@ describe('official model manager provider boundary', () => {
       ).toBe(false);
     });
     manager.dispose();
+  });
+
+  it('preserves Command Code routing identity across an official-model cache restart', async () => {
+    const config = commandCodeProvider();
+    const storage = new Map<string, unknown>();
+    providerClient.getAvailableModels.mockResolvedValue([
+      {
+        id: 'opaque-id',
+        name: 'Claude Model With Opaque ID',
+        maxInputTokens: 1_000_000,
+      },
+    ]);
+    const firstManager = new OfficialModelsManager();
+    await firstManager.initialize(
+      context(storage),
+      configStore(config),
+      secretStore(),
+      authManager(false),
+    );
+    await firstManager.getOfficialModels(config, true);
+    firstManager.dispose();
+
+    const serialized = JSON.stringify(storage.get('officialModelsState'));
+    const reloadedState: unknown = JSON.parse(serialized);
+    const restartedStorage = new Map<string, unknown>([
+      ['officialModelsState', reloadedState],
+    ]);
+    providerClient.getAvailableModels.mockReset();
+    const secondManager = new OfficialModelsManager();
+    await secondManager.initialize(
+      context(restartedStorage),
+      configStore(config),
+      secretStore(),
+      authManager(false),
+    );
+
+    const models = await secondManager.getOfficialModels(config);
+
+    expect(providerClient.getAvailableModels).not.toHaveBeenCalled();
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'opaque-id',
+        name: 'Claude Model With Opaque ID',
+        maxInputTokens: 1_000_000,
+      }),
+    ]);
+    expect(resolveCommandCodeProtocol(models[0])).toBe('anthropic-messages');
+    secondManager.dispose();
   });
 });


### PR DESCRIPTION
## Summary

- add one built-in `command-code` provider with one configuration, one credential, and one model catalog
- request and strictly parse the official catalog once from `/provider/v1/models`, preserving each model's `context_length`
- support the complete synchronized catalog through the single Command Code provider while reusing the project's established request clients
- make model-specific successful empty streams explicit provider behavior so they are not retried and billed twice
- preserve one provider/model identity through configuration import/export, UI selection, official-model caching, and restart behavior
- keep the existing shared request clients and official-model manager unchanged from `main`
- document and localize the provider's API and automatic model synchronization

## Main-instance compatibility

The new `command-code` provider type is carried through main-instance configuration, RPC validation, and shared provider state. Version 8 instances cannot recognize and preserve that new contract, so `MAIN_INSTANCE_COMPATIBILITY_VERSION` is bumped from 8 to 9. `PROTOCOL_VERSION` remains 1, and the extension/package version is not used as the compatibility boundary.

Regression coverage verifies that version 9 leaders and followers coordinate across different extension versions, while 8-to-9 and 9-to-8 pairings are isolated.

## Validation

- `npm run compile`
- `npm run test:unit` (116 files, 1,396 tests passed)
- strict TypeScript checks for source and unit tests
- `npm run l10n:check`
- `npm run verify:chat-lib`
- `git diff --check`
- full VS Code Extension Host E2E: completion lifecycle/parity, disabled Proposed API fallback, and all three auth-isolation phases
- targeted coverage for catalog identity normalization, API URL construction, authentication and argument forwarding, strict catalog parsing, successful empty streams, cache restart behavior, compatibility, import/export, UI identity, and completion-registry exclusion
- live public catalog check: 61 models available
- confirmed that the existing shared request clients and official-model manager have zero diff from `main`

## Residual risk

No paid Command Code API key was available, so authenticated chat requests were not exercised end to end. The public catalog, provider construction, authentication and request forwarding boundaries, parsing, caching, and model handling were verified without making paid requests.

Fixes #313
